### PR TITLE
Scintilla Integration (and smaller code changes)

### DIFF
--- a/StonehearthEditor/AliasSelectionDialog.cs
+++ b/StonehearthEditor/AliasSelectionDialog.cs
@@ -1,87 +1,83 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Windows.Forms;
 
 namespace StonehearthEditor
 {
     public partial class AliasSelectionDialog : Form
-   {
-      public interface IDialogCallback
-      {
-         // Returns true if we can close the dialog
-         bool OnAccept(HashSet<string> aliases);
+    {
+        public interface IDialogCallback
+        {
+            // Returns true if we can close the dialog
+            bool OnAccept(IEnumerable<string> aliases);
 
-         void OnCancelled();
-      }
+            void OnCancelled();
+        }
 
-      private HashSet<string> mAllAliases = new HashSet<string>();
-      private IDialogCallback mCallback;
+        private HashSet<string> mAllAliases = new HashSet<string>();
+        private IDialogCallback mCallback;
 
-      public AliasSelectionDialog(IDialogCallback callback)
-      {
-         InitializeComponent();
-         mCallback = callback;
-         foreach (Module mod in ModuleDataManager.GetInstance().GetAllModules())
-         {
-            foreach (ModuleFile alias in mod.GetAliases())
+        public AliasSelectionDialog(IDialogCallback callback)
+        {
+            InitializeComponent();
+            mCallback = callback;
+            foreach (Module mod in ModuleDataManager.GetInstance().GetAllModules())
             {
-               mAllAliases.Add(alias.FullAlias);
-            }
-         }
-
-         SetFilter(null);
-      }
-
-      private void SetFilter(string filter)
-      {
-         bool isEmpty = string.IsNullOrWhiteSpace(filter);
-         listBox.Items.Clear();
-         foreach (string alias in mAllAliases)
-         {
-            if (isEmpty || alias.Contains(filter))
-            {
-               listBox.Items.Add(alias);
-            }
-         }
-      }
-
-      private void filterTextBox_TextChanged(object sender, EventArgs e)
-      {
-         SetFilter(filterTextBox.Text);
-      }
-
-      private void acceptButton_Click(object sender, EventArgs e)
-      {
-         if (mCallback != null)
-         {
-            HashSet<string> selected = new HashSet<string>();
-            foreach (object obj in listBox.SelectedItems)
-            {
-               string alias = (string)obj;
-               selected.Add(alias);
+                foreach (ModuleFile alias in mod.GetAliases())
+                {
+                    mAllAliases.Add(alias.FullAlias);
+                }
             }
 
-            bool isSuccess = mCallback.OnAccept(selected);
-            if (isSuccess)
+            SetFilter(null);
+        }
+
+        private void SetFilter(string filter)
+        {
+            bool isEmpty = string.IsNullOrWhiteSpace(filter);
+            listBox.Items.Clear();
+            foreach (string alias in mAllAliases)
             {
-               mCallback = null;
-               Close();
+                if (isEmpty || alias.Contains(filter))
+                {
+                    listBox.Items.Add(alias);
+                }
             }
-         }
-      }
+        }
 
-      private void AliasSelectionDialog_FormClosed(object sender, FormClosedEventArgs e)
-      {
-         if (mCallback != null)
-         {
-            mCallback.OnCancelled();
-            mCallback = null;
-         }
-      }
+        private void filterTextBox_TextChanged(object sender, EventArgs e)
+        {
+            SetFilter(filterTextBox.Text);
+        }
 
-      private void listBox_MouseDoubleClick(object sender, MouseEventArgs e)
-      {
-         acceptButton.PerformClick();
-      }
-   }
+        private void acceptButton_Click(object sender, EventArgs e)
+        {
+            if (mCallback != null)
+            {
+                // Casts the listbox items to strings (throws an exception should anything be uncastable),
+                // then selects only unique (distinct) elements and passes that to OnAccept as IEnumerable<string>
+                bool isSuccess = mCallback.OnAccept(listBox.SelectedItems.Cast<string>().Distinct());
+                if (isSuccess)
+                {
+                    mCallback = null;
+                    Close();
+                }
+            }
+        }
+
+        private void AliasSelectionDialog_FormClosed(object sender, FormClosedEventArgs e)
+        {
+            if (mCallback != null)
+            {
+                mCallback.OnCancelled();
+                mCallback = null;
+            }
+        }
+
+        private void listBox_MouseDoubleClick(object sender, MouseEventArgs e)
+        {
+            acceptButton.PerformClick();
+        }
+    }
 }

--- a/StonehearthEditor/FilePreview.Designer.cs
+++ b/StonehearthEditor/FilePreview.Designer.cs
@@ -28,144 +28,145 @@
       /// </summary>
       private void InitializeComponent()
       {
-         this.components = new System.ComponentModel.Container();
-         System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(FilePreview));
-         this.textBox = new System.Windows.Forms.RichTextBox();
-         this.filePreviewContextMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
-         this.saveToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-         this.insertAliasToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-         this.editLocStringToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-         this.i18nTooltip = new System.Windows.Forms.ToolTip(this.components);
-         this.toolStrip = new System.Windows.Forms.ToolStrip();
-         this.openFile = new System.Windows.Forms.ToolStripButton();
-         this.openFolder = new System.Windows.Forms.ToolStripButton();
-         this.saveFile = new System.Windows.Forms.ToolStripButton();
-         this.localizeFile = new System.Windows.Forms.ToolStripButton();
-         this.filePreviewContextMenu.SuspendLayout();
-         this.toolStrip.SuspendLayout();
-         this.SuspendLayout();
-         // 
-         // textBox
-         // 
-         this.textBox.ContextMenuStrip = this.filePreviewContextMenu;
-         this.textBox.Dock = System.Windows.Forms.DockStyle.Fill;
-         this.textBox.Font = new System.Drawing.Font("Consolas", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-         this.textBox.Location = new System.Drawing.Point(0, 25);
-         this.textBox.Name = "textBox";
-         this.textBox.Size = new System.Drawing.Size(150, 125);
-         this.textBox.TabIndex = 0;
-         this.textBox.Text = "";
-         this.textBox.WordWrap = false;
-         this.textBox.KeyDown += new System.Windows.Forms.KeyEventHandler(this.textBox_KeyDown);
-         this.textBox.Leave += new System.EventHandler(this.textBox_Leave);
-         this.textBox.MouseMove += new System.Windows.Forms.MouseEventHandler(this.textBox_MouseMove);
-         // 
-         // filePreviewContextMenu
-         // 
-         this.filePreviewContextMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.components = new System.ComponentModel.Container();
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(FilePreview));
+            this.textBox = new ScintillaNET.Scintilla();
+            this.filePreviewContextMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.saveToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.insertAliasToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.editLocStringToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.i18nTooltip = new System.Windows.Forms.ToolTip(this.components);
+            this.toolStrip = new System.Windows.Forms.ToolStrip();
+            this.openFile = new System.Windows.Forms.ToolStripButton();
+            this.openFolder = new System.Windows.Forms.ToolStripButton();
+            this.saveFile = new System.Windows.Forms.ToolStripButton();
+            this.localizeFile = new System.Windows.Forms.ToolStripButton();
+            this.filePreviewContextMenu.SuspendLayout();
+            this.toolStrip.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // textBox
+            // 
+            this.textBox.ContextMenuStrip = this.filePreviewContextMenu;
+            this.textBox.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.textBox.Font = new System.Drawing.Font("Consolas", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.textBox.Location = new System.Drawing.Point(0, 25);
+            this.textBox.MouseDwellTime = 10;
+            this.textBox.Name = "textBox";
+            this.textBox.Size = new System.Drawing.Size(150, 125);
+            this.textBox.TabIndex = 0;
+            this.textBox.UseTabs = false;
+            this.textBox.IndicatorRelease += new System.EventHandler<ScintillaNET.IndicatorReleaseEventArgs>(this.textBox_IndicatorRelease);
+            this.textBox.SavePointLeft += new System.EventHandler<System.EventArgs>(this.textBox_SavePointLeft);
+            this.textBox.SavePointReached += new System.EventHandler<System.EventArgs>(this.textBox_SavePointReached);
+            this.textBox.KeyDown += new System.Windows.Forms.KeyEventHandler(this.textBox_KeyDown);
+            this.textBox.Leave += new System.EventHandler(this.textBox_Leave);
+            this.textBox.MouseMove += new System.Windows.Forms.MouseEventHandler(this.textBox_MouseMove);
+            // 
+            // filePreviewContextMenu
+            // 
+            this.filePreviewContextMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.saveToolStripMenuItem,
             this.insertAliasToolStripMenuItem,
             this.editLocStringToolStripMenuItem});
-         this.filePreviewContextMenu.Name = "filePreviewContextMenu";
-         this.filePreviewContextMenu.Size = new System.Drawing.Size(197, 70);
-         this.filePreviewContextMenu.Opening += new System.ComponentModel.CancelEventHandler(this.filePreviewContextMenu_Opening);
-         // 
-         // saveToolStripMenuItem
-         // 
-         this.saveToolStripMenuItem.Name = "saveToolStripMenuItem";
-         this.saveToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.S)));
-         this.saveToolStripMenuItem.Size = new System.Drawing.Size(196, 22);
-         this.saveToolStripMenuItem.Text = "Save";
-         this.saveToolStripMenuItem.Click += new System.EventHandler(this.saveToolStripMenuItem_Click);
-         // 
-         // insertAliasToolStripMenuItem
-         // 
-         this.insertAliasToolStripMenuItem.Name = "insertAliasToolStripMenuItem";
-         this.insertAliasToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Space)));
-         this.insertAliasToolStripMenuItem.Size = new System.Drawing.Size(196, 22);
-         this.insertAliasToolStripMenuItem.Text = "Insert Alias";
-         this.insertAliasToolStripMenuItem.Click += new System.EventHandler(this.insertAliasToolStripMenuItem_Click);
-         // 
-         // editLocStringToolStripMenuItem
-         // 
-         this.editLocStringToolStripMenuItem.Name = "editLocStringToolStripMenuItem";
-         this.editLocStringToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.L)));
-         this.editLocStringToolStripMenuItem.Size = new System.Drawing.Size(196, 22);
-         this.editLocStringToolStripMenuItem.Text = "Edit Loc String";
-         this.editLocStringToolStripMenuItem.Click += new System.EventHandler(this.editLocStringToolStripMenuItem_Click);
-         // 
-         // toolStrip
-         // 
-         this.toolStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.filePreviewContextMenu.Name = "filePreviewContextMenu";
+            this.filePreviewContextMenu.Size = new System.Drawing.Size(197, 70);
+            this.filePreviewContextMenu.Opening += new System.ComponentModel.CancelEventHandler(this.filePreviewContextMenu_Opening);
+            // 
+            // saveToolStripMenuItem
+            // 
+            this.saveToolStripMenuItem.Name = "saveToolStripMenuItem";
+            this.saveToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.S)));
+            this.saveToolStripMenuItem.Size = new System.Drawing.Size(196, 22);
+            this.saveToolStripMenuItem.Text = "Save";
+            this.saveToolStripMenuItem.Click += new System.EventHandler(this.saveToolStripMenuItem_Click);
+            // 
+            // insertAliasToolStripMenuItem
+            // 
+            this.insertAliasToolStripMenuItem.Name = "insertAliasToolStripMenuItem";
+            this.insertAliasToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Space)));
+            this.insertAliasToolStripMenuItem.Size = new System.Drawing.Size(196, 22);
+            this.insertAliasToolStripMenuItem.Text = "Insert Alias";
+            this.insertAliasToolStripMenuItem.Click += new System.EventHandler(this.insertAliasToolStripMenuItem_Click);
+            // 
+            // editLocStringToolStripMenuItem
+            // 
+            this.editLocStringToolStripMenuItem.Name = "editLocStringToolStripMenuItem";
+            this.editLocStringToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.L)));
+            this.editLocStringToolStripMenuItem.Size = new System.Drawing.Size(196, 22);
+            this.editLocStringToolStripMenuItem.Text = "Edit Loc String";
+            this.editLocStringToolStripMenuItem.Click += new System.EventHandler(this.editLocStringToolStripMenuItem_Click);
+            // 
+            // toolStrip
+            // 
+            this.toolStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.openFile,
             this.openFolder,
             this.saveFile,
             this.localizeFile});
-         this.toolStrip.Location = new System.Drawing.Point(0, 0);
-         this.toolStrip.Name = "toolStrip";
-         this.toolStrip.Size = new System.Drawing.Size(150, 25);
-         this.toolStrip.TabIndex = 2;
-         this.toolStrip.Text = "toolStrip1";
-         // 
-         // openFile
-         // 
-         this.openFile.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-         this.openFile.Image = ((System.Drawing.Image)(resources.GetObject("openFile.Image")));
-         this.openFile.ImageTransparentColor = System.Drawing.Color.Magenta;
-         this.openFile.Name = "openFile";
-         this.openFile.Size = new System.Drawing.Size(23, 22);
-         this.openFile.Text = "Open File in Text Editor";
-         this.openFile.Click += new System.EventHandler(this.openFile_Click);
-         // 
-         // openFolder
-         // 
-         this.openFolder.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-         this.openFolder.Image = ((System.Drawing.Image)(resources.GetObject("openFolder.Image")));
-         this.openFolder.ImageTransparentColor = System.Drawing.Color.Magenta;
-         this.openFolder.Name = "openFolder";
-         this.openFolder.Size = new System.Drawing.Size(23, 22);
-         this.openFolder.Text = "Open Containing Folder";
-         this.openFolder.Click += new System.EventHandler(this.openFolder_Click);
-         // 
-         // saveFile
-         // 
-         this.saveFile.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-         this.saveFile.Image = ((System.Drawing.Image)(resources.GetObject("saveFile.Image")));
-         this.saveFile.ImageTransparentColor = System.Drawing.Color.Magenta;
-         this.saveFile.Name = "saveFile";
-         this.saveFile.Size = new System.Drawing.Size(23, 22);
-         this.saveFile.Text = "Save File";
-         this.saveFile.Click += new System.EventHandler(this.saveFile_Click);
-         // 
-         // localizeFile
-         // 
-         this.localizeFile.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-         this.localizeFile.Image = ((System.Drawing.Image)(resources.GetObject("localizeFile.Image")));
-         this.localizeFile.ImageTransparentColor = System.Drawing.Color.Magenta;
-         this.localizeFile.Name = "localizeFile";
-         this.localizeFile.Size = new System.Drawing.Size(23, 22);
-         this.localizeFile.Text = "Localize This File";
-         this.localizeFile.Click += new System.EventHandler(this.localizeFile_Click);
-         // 
-         // FilePreview
-         // 
-         this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-         this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-         this.ContextMenuStrip = this.filePreviewContextMenu;
-         this.Controls.Add(this.textBox);
-         this.Controls.Add(this.toolStrip);
-         this.Name = "FilePreview";
-         this.filePreviewContextMenu.ResumeLayout(false);
-         this.toolStrip.ResumeLayout(false);
-         this.toolStrip.PerformLayout();
-         this.ResumeLayout(false);
-         this.PerformLayout();
+            this.toolStrip.Location = new System.Drawing.Point(0, 0);
+            this.toolStrip.Name = "toolStrip";
+            this.toolStrip.Size = new System.Drawing.Size(150, 25);
+            this.toolStrip.TabIndex = 2;
+            this.toolStrip.Text = "toolStrip1";
+            // 
+            // openFile
+            // 
+            this.openFile.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.openFile.Image = ((System.Drawing.Image)(resources.GetObject("openFile.Image")));
+            this.openFile.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.openFile.Name = "openFile";
+            this.openFile.Size = new System.Drawing.Size(23, 22);
+            this.openFile.Text = "Open File in Text Editor";
+            this.openFile.Click += new System.EventHandler(this.openFile_Click);
+            // 
+            // openFolder
+            // 
+            this.openFolder.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.openFolder.Image = ((System.Drawing.Image)(resources.GetObject("openFolder.Image")));
+            this.openFolder.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.openFolder.Name = "openFolder";
+            this.openFolder.Size = new System.Drawing.Size(23, 22);
+            this.openFolder.Text = "Open Containing Folder";
+            this.openFolder.Click += new System.EventHandler(this.openFolder_Click);
+            // 
+            // saveFile
+            // 
+            this.saveFile.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.saveFile.Image = ((System.Drawing.Image)(resources.GetObject("saveFile.Image")));
+            this.saveFile.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.saveFile.Name = "saveFile";
+            this.saveFile.Size = new System.Drawing.Size(23, 22);
+            this.saveFile.Text = "Save File";
+            this.saveFile.Click += new System.EventHandler(this.saveFile_Click);
+            // 
+            // localizeFile
+            // 
+            this.localizeFile.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.localizeFile.Image = ((System.Drawing.Image)(resources.GetObject("localizeFile.Image")));
+            this.localizeFile.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.localizeFile.Name = "localizeFile";
+            this.localizeFile.Size = new System.Drawing.Size(23, 22);
+            this.localizeFile.Text = "Localize This File";
+            this.localizeFile.Click += new System.EventHandler(this.localizeFile_Click);
+            // 
+            // FilePreview
+            // 
+            this.ContextMenuStrip = this.filePreviewContextMenu;
+            this.Controls.Add(this.textBox);
+            this.Controls.Add(this.toolStrip);
+            this.Name = "FilePreview";
+            this.filePreviewContextMenu.ResumeLayout(false);
+            this.toolStrip.ResumeLayout(false);
+            this.toolStrip.PerformLayout();
+            this.ResumeLayout(false);
+            this.PerformLayout();
 
       }
 
       #endregion
 
-      private System.Windows.Forms.RichTextBox textBox;
+      private ScintillaNET.Scintilla textBox;
       private System.Windows.Forms.ToolTip i18nTooltip;
       private System.Windows.Forms.ContextMenuStrip filePreviewContextMenu;
       private System.Windows.Forms.ToolStripMenuItem saveToolStripMenuItem;

--- a/StonehearthEditor/FilePreview.cs
+++ b/StonehearthEditor/FilePreview.cs
@@ -184,7 +184,7 @@ namespace StonehearthEditor
             {
                 // Enquotes every single alias and joins it using "\n,"
                 string aliasInsert = string.Join(
-                    Environment.NewLine + ",",
+                    "," + Environment.NewLine,
                     aliases.Select(alias => string.Concat('"', alias, '"')));
 
                 mTextBox.InsertText(mTextBox.SelectionStart, aliasInsert);

--- a/StonehearthEditor/FilePreview.cs
+++ b/StonehearthEditor/FilePreview.cs
@@ -2,19 +2,41 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Windows.Forms;
 using Newtonsoft.Json.Linq;
+using ScintillaNET;
+using Color = System.Drawing.Color;
 
 namespace StonehearthEditor
 {
     public partial class FilePreview : UserControl
     {
         private FileData mFileData;
-        private int mI18nTooltipLine = -1;
         private string mI18nLocKey = null;
         private IReloadable mOwner;
+
+        /// <summary>
+        /// Index of the indicator for i18n()
+        /// </summary>
+        private const int kI18nIndicator = 8;
+
+        /// <summary>
+        /// Index of the indicator for file() and file-ish things
+        /// </summary>
+        private const int kFileIndicator = 9;
+
+        /// <summary>
+        /// Indicator for i18n()
+        /// </summary>
+        private Indicator mI18nIndicator => this.textBox.Indicators[kI18nIndicator];
+
+        /// <summary>
+        /// Indicator for file() and file-ish things
+        /// </summary>
+        private Indicator mFileIndicator => this.textBox.Indicators[kFileIndicator];
 
         public FilePreview(IReloadable owner, FileData fileData)
         {
@@ -22,6 +44,8 @@ namespace StonehearthEditor
             InitializeComponent();
             textBox.Text = mFileData.FlatFileData;
             mOwner = owner;
+
+            this.configureScintilla();
         }
 
         private void textBox_Leave(object sender, EventArgs e)
@@ -31,36 +55,31 @@ namespace StonehearthEditor
 
         private void textBox_MouseMove(object sender, MouseEventArgs e)
         {
-            int charIndex = textBox.GetCharIndexFromPosition(e.Location);
-            int line = textBox.GetLineFromCharIndex(charIndex);
+            // Translate mouse xy to character position
+            var position = this.textBox.CharPositionFromPoint(e.X, e.Y);
+            var locKey = this.getLocKey(position);
 
-            if (textBox.Lines.Length <= line)
+            if (locKey == this.mI18nLocKey)
+                return;
+
+            this.mI18nLocKey = locKey;
+
+            if (locKey == null)
             {
+                this.textBox.CallTipCancel();
                 return;
             }
 
-            if (mI18nTooltipLine == line)
+            try
             {
-                return;
+                // Translate and display it as a tip
+                var translated = ModuleDataManager.GetInstance().LocalizeString(locKey);
+                translated = JsonHelper.WordWrap(translated, 100).Trim();
+                this.textBox.CallTipShow(position, translated);
             }
-
-            i18nTooltip.Hide(textBox);
-
-            mI18nTooltipLine = line;
-            string lineString = textBox.Lines[line];
-            Regex matcher = new Regex(@"i18n\(([^)]+)\)");
-            Match locMatch = matcher.Match(lineString);
-            if (locMatch.Success)
+            catch (Exception)
             {
-                mI18nLocKey = locMatch.Groups[1].Value;
-                string translated = ModuleDataManager.GetInstance().LocalizeString(mI18nLocKey);
-                translated = JsonHelper.WordWrap(translated, 100);
-                i18nTooltip.Show(translated, textBox, e.Location);
-            }
-            else
-            {
-                i18nTooltip.Hide(textBox);
-                mI18nLocKey = null;
+                this.textBox.CallTipShow(position, $"(Uncaught exception while trying to find i18n for {locKey})");
             }
         }
 
@@ -78,30 +97,20 @@ namespace StonehearthEditor
             }
 
             mFileData.TrySaveFile();
-            // rescroll to correct location
-            int caretPosition = textBox.SelectionStart;
-            textBox.Text = mFileData.FlatFileData;
-            textBox.SelectionStart = caretPosition;
-            textBox.ScrollToCaret();
 
+            this.textBox.SetSavePoint();
             TabPage parentControl = Parent as TabPage;
             if (parentControl != null)
             {
+                int caretPosition = textBox.SelectionStart;
+                textBox.SelectionStart = caretPosition;
+                textBox.ScrollCaret();
                 parentControl.Text = mFileData.FileName;
             }
         }
 
         private void textBox_KeyDown(object sender, KeyEventArgs e)
         {
-            TabPage parentControl = Parent as TabPage;
-            if (parentControl != null)
-            {
-                if (!mFileData.FlatFileData.Equals(textBox.Text))
-                {
-                    parentControl.Text = mFileData.FileName + "*";
-                }
-            }
-
             if (e.KeyCode == Keys.Tab)
             {
                 e.Handled = true;
@@ -164,30 +173,22 @@ namespace StonehearthEditor
 
         private class AliasSelectCallback : AliasSelectionDialog.IDialogCallback
         {
-            private RichTextBox mTextBox;
+            private Scintilla mTextBox;
 
-            public AliasSelectCallback(RichTextBox textbox)
+            public AliasSelectCallback(Scintilla textbox)
             {
                 mTextBox = textbox;
             }
 
-            public bool OnAccept(HashSet<string> aliases)
+            public bool OnAccept(IEnumerable<string> aliases)
             {
-                StringBuilder aliasInsert = new StringBuilder();
-                bool isFirst = true;
-                foreach (string alias in aliases)
-                {
-                    if (!isFirst)
-                    {
-                        aliasInsert.AppendLine(",");
-                    }
+                // Enquotes every single alias and joins it using "\n,"
+                string aliasInsert = string.Join(
+                    Environment.NewLine + ",",
+                    aliases.Select(alias => string.Concat('"', alias, '"')));
 
-                    isFirst = false;
-                    aliasInsert.Append('"' + alias + '"');
-                }
-
-                mTextBox.SelectionLength = 0;
-                mTextBox.SelectedText = aliasInsert.ToString();
+                mTextBox.InsertText(mTextBox.SelectionStart, aliasInsert);
+                mTextBox.SelectionEnd = mTextBox.SelectionEnd + aliasInsert.Length;
                 return true;
             }
 
@@ -290,6 +291,329 @@ namespace StonehearthEditor
             else
             {
                 editLocStringToolStripMenuItem.Visible = false;
+            }
+        }
+
+        /// <summary>
+        /// Sets up some more things about <see cref="textBox"/>.
+        /// </summary>
+        private void configureScintilla()
+        {
+            // Make sure we start proper
+            textBox.SetSavePoint();
+            textBox.EmptyUndoBuffer();
+
+            // Set the default style
+            textBox.StyleResetDefault();
+            textBox.Styles[Style.Default].Font = "Consolas";
+            textBox.Styles[Style.Default].Size = 10;
+            textBox.Styles[Style.Default].ForeColor = Color.Black;
+            textBox.StyleClearAll();
+
+            // Based on the extension, we need to choose the right lexer/style
+            switch (System.IO.Path.GetExtension(mFileData.Path))
+            {
+                case ".lua":
+                case ".luac":
+                    this.configureLuaHighlighting();
+                    break;
+                case ".js":
+                case ".json":
+                    this.configureJsonHighlighting();
+                    break;
+                case ".css":
+                case ".less":
+                    textBox.Lexer = ScintillaNET.Lexer.Css;
+                    break;
+                case ".html":
+                case ".htm":
+                    textBox.Lexer = ScintillaNET.Lexer.Html;
+                    break;
+                case ".md":
+                    textBox.Lexer = ScintillaNET.Lexer.Markdown;
+                    break;
+                case ".xml":
+                    textBox.Lexer = ScintillaNET.Lexer.Xml;
+                    break;
+            }
+
+            this.textBox.Styles[Style.CallTip].SizeF = 8.25f;
+            this.textBox.Styles[Style.CallTip].ForeColor = Color.Black;
+            this.textBox.Styles[Style.CallTip].BackColor = Color.White;
+            this.textBox.Styles[Style.CallTip].Font = "Verdana";
+            this.textBox.Styles[Style.CallTip].Hotspot = true;
+
+            this.textBox.TextChanged += (sender, e) => this.restyleDocument();
+            this.restyleDocument();
+        }
+
+        /// <summary>
+        /// Configures Scintilla for Json highlighting
+        /// </summary>
+        private void configureJsonHighlighting()
+        {
+            textBox.Lexer = ScintillaNET.Lexer.Cpp;
+
+            var scintilla = textBox;
+            scintilla.Styles[ScintillaNET.Style.Cpp.Number].Bold = true;
+            scintilla.Styles[ScintillaNET.Style.Cpp.Number].ForeColor = Color.Navy;
+            scintilla.Styles[ScintillaNET.Style.Cpp.Number].Weight = 700;
+            scintilla.Styles[ScintillaNET.Style.Cpp.String].ForeColor = Color.Purple;
+            scintilla.Styles[ScintillaNET.Style.Cpp.Identifier].Bold = true;
+            scintilla.Styles[ScintillaNET.Style.Cpp.Identifier].ForeColor = Color.ForestGreen;
+            scintilla.Styles[ScintillaNET.Style.Cpp.Identifier].Weight = 700;
+
+            // Prepare indicator
+            this.mI18nIndicator.Style = IndicatorStyle.FullBox;
+            this.mI18nIndicator.ForeColor = Color.CornflowerBlue;
+            this.mI18nIndicator.HoverForeColor = Color.CadetBlue;
+            this.mI18nIndicator.Alpha = 50;
+
+            this.mFileIndicator.Style = IndicatorStyle.FullBox;
+            this.mFileIndicator.ForeColor = Color.Green;
+            this.mFileIndicator.HoverForeColor = Color.DarkGreen;
+            this.mFileIndicator.Alpha = 50;
+        }
+
+        /// <summary>
+        /// Helper used in <see cref="restyleDocument"/>
+        /// </summary>
+        /// <param name="pattern"></param>
+        /// <param name="targetTransform"></param>
+        private void indicate(string pattern, Action targetTransform = null)
+        {
+            textBox.TargetWholeDocument();
+
+            while (textBox.SearchInTarget(pattern) != -1)
+            {
+                // Invoke transformation, if any was submitted
+                targetTransform?.Invoke();
+
+                // Only indicate if there's something to indicate
+                if (textBox.TargetStart != textBox.TargetEnd)
+                    textBox.IndicatorFillRange(textBox.TargetStart, textBox.TargetEnd - textBox.TargetStart);
+                textBox.TargetStart = textBox.TargetEnd;
+                textBox.TargetEnd = textBox.TextLength;
+            }
+        }
+
+        /// <summary>
+        /// Called whenever a change was made;
+        /// used to re-style the whole document.
+        /// Sets indicators.
+        /// </summary>
+        private void restyleDocument()
+        {
+            var scintilla = this.textBox;
+
+            // Reset all indicators
+            scintilla.IndicatorClearRange(0, scintilla.TextLength);
+
+            // Search for fitting texts
+            scintilla.SearchFlags = SearchFlags.Regex | SearchFlags.Posix;
+
+            scintilla.IndicatorCurrent = kI18nIndicator;
+            this.indicate(@"i18n\(.+?\)");
+            scintilla.IndicatorCurrent = kFileIndicator;
+            this.indicate(@"""[^"" ]*?:[^"" ]*?""", this.transformFileNames);
+            this.indicate(@"file\(.+?\)", this.transformFileNames);
+            this.indicate(@"""[^""]*?/[^""]*?""", this.transformFileNames);
+        }
+
+        /// <summary>
+        /// Helper function for <see cref="restyleDocument"/>/<see cref="indicate(string, Action)"/>
+        /// </summary>
+        private void transformFileNames()
+        {
+            var text = this.textBox.TargetText;
+
+            // Trim quotes if necessary
+            if (text.StartsWith(@"""") && text.EndsWith(@""""))
+            {
+                this.textBox.TargetStart++;
+                this.textBox.TargetEnd--;
+                text = text.Substring(1, text.Length - 2);
+            }
+
+            // If it's not a valid file, we won't highlight it
+            if (!this.isValidFileName(text))
+                this.textBox.TargetStart = this.textBox.TargetEnd;
+        }
+
+        /// <summary>
+        /// Configures Scintilla for lua highlighting
+        /// </summary>
+        private void configureLuaHighlighting()
+        {
+            var scintilla = textBox;
+            scintilla.Lexer = ScintillaNET.Lexer.Lua;
+
+            scintilla.Styles[ScintillaNET.Style.Lua.Comment].BackColor = Color.LightCyan;
+            scintilla.Styles[ScintillaNET.Style.Lua.Comment].FillLine = true;
+            scintilla.Styles[ScintillaNET.Style.Lua.Comment].ForeColor = Color.Green;
+            scintilla.Styles[ScintillaNET.Style.Lua.CommentLine].ForeColor = Color.Green;
+            scintilla.Styles[ScintillaNET.Style.Lua.Number].ForeColor = Color.DarkCyan;
+            scintilla.Styles[ScintillaNET.Style.Lua.Word].ForeColor = Color.Navy;
+            scintilla.Styles[ScintillaNET.Style.Lua.String].ForeColor = Color.BlueViolet;
+            scintilla.Styles[ScintillaNET.Style.Lua.Character].ForeColor = Color.BlueViolet;
+            scintilla.Styles[ScintillaNET.Style.Lua.StringEol].BackColor = Color.BlueViolet;
+            scintilla.Styles[ScintillaNET.Style.Lua.StringEol].ForeColor = Color.White;
+            scintilla.Styles[ScintillaNET.Style.Lua.Word2].BackColor = Color.Maroon;
+
+            scintilla.SetKeywords(0, "and break do else elseif end for function if in local nil not or repeat return then until while");
+        }
+
+        /// <summary>
+        /// Returns the index of the indicator at <paramref name="position"/>
+        /// </summary>
+        /// <param name="position">Position in the <see cref="textBox"/> that should be queried.</param>
+        /// <returns>The index of the indicator if found, -1 otherwise.</returns>
+        private int getIndicatorAt(int position)
+        {
+            // We're not going to style stuff with two indicators.
+            switch (this.textBox.IndicatorAllOnFor(position))
+            {
+                case 1 << kI18nIndicator:
+                    return kI18nIndicator;
+                case 1 << kFileIndicator:
+                    return kFileIndicator;
+                default:
+                    return -1;
+            }
+        }
+
+        /// <summary>
+        /// Returns the text that's indicated with <paramref name="indicator"/>
+        /// at position <paramref name="position"/>
+        /// </summary>
+        /// <param name="indicator">Indicator used to style the text</param>
+        /// <param name="position">Position to query</param>
+        /// <returns>The complete text that was styled with this indicator</returns>
+        private string getIndicatorText(Indicator indicator, int position)
+        {
+            var startPos = indicator.Start(position);
+            var endPos = indicator.End(position);
+            return this.textBox.GetTextRange(startPos, endPos - startPos);
+        }
+
+        /// <summary>
+        /// Returns the localisation key at position <paramref name="position"/>.
+        /// </summary>
+        /// <param name="position">Position that should be queried.</param>
+        /// <returns>The localisation key, without i18n()</returns>
+        private string getLocKey(int position)
+        {
+            if (this.getIndicatorAt(position) != kI18nIndicator)
+                return null;
+
+            var indicator = this.mI18nIndicator;
+            var startPos = indicator.Start(position);
+            var endPos = indicator.End(position);
+            var locKey = this.textBox.GetTextRange(startPos, endPos - startPos);
+            var i18nLength = "i18n(".Length;
+            return locKey.Substring(i18nLength, locKey.Length - i18nLength - 1);
+        }
+
+        /// <summary>
+        /// Whenever the user clicked on an indicator.
+        /// Used instead of IndicatorClick because the opening dialog is eating the
+        /// Release event, so the control thinks there's text to be selected.
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void textBox_IndicatorRelease(object sender, IndicatorReleaseEventArgs e)
+        {
+            if (!ModifierKeys.HasFlag(Keys.Control))
+                return;
+
+            int indicator = this.getIndicatorAt(e.Position);
+
+            if (indicator == kI18nIndicator)
+            {
+                var locKey = this.getLocKey(e.Position);
+
+                if (locKey != null)
+                {
+                    this.mI18nLocKey = locKey;
+                    EditLocStringCallback callback = new EditLocStringCallback(this.mI18nLocKey);
+                    string translated = ModuleDataManager.GetInstance().LocalizeString(this.mI18nLocKey);
+                    InputDialog dialog = new InputDialog("Edit Loc String", $"Edit Loc Text For: {mI18nLocKey}", translated, "Edit");
+                    dialog.SetCallback(callback);
+                    dialog.ShowDialog();
+                }
+            }
+            else if (indicator == kFileIndicator)
+            {
+                var text = this.getIndicatorText(this.mFileIndicator, e.Position);
+                ModuleFile module;
+                if (!this.tryGetModuleFile(text, out module) || module == null)
+                    return;
+
+                var selectable = mOwner as IFileDataSelectable;
+
+                // TODO: instead of using an interface, try to have some function in
+                // the main view that allows switching to the manifest view + displaying a modulefile/filedata
+                if (selectable != null)
+                    selectable.SetSelectedFileData(module.FileData);
+            }
+        }
+
+        /// <summary>
+        /// Tries to convert a string to an (openable) file
+        /// </summary>
+        /// <param name="text"></param>
+        /// <param name="module"></param>
+        /// <returns></returns>
+        private bool tryGetModuleFile(string text, out ModuleFile module)
+        {
+            module = null;
+
+            // Simple checks
+            if (text.StartsWith("i18n(") || text.IndexOfAny(new[] { ':', '/' }) == -1)
+                return false;
+
+            var parent = System.IO.Path.GetDirectoryName(this.mFileData.Path);
+            return ModuleDataManager.GetInstance().TryGetModuleFile(text, parent, out module);
+        }
+
+        /// <summary>
+        /// Returns whether a certain string maps to a file (that can be opened)
+        /// </summary>
+        /// <param name="text"></param>
+        /// <returns></returns>
+        private bool isValidFileName(string text)
+        {
+            ModuleFile dummy;
+            return tryGetModuleFile(text, out dummy) && dummy != null;
+        }
+
+        /// <summary>
+        /// Called whenever the text is modified
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void textBox_SavePointLeft(object sender, EventArgs e)
+        {
+            TabPage parentControl = Parent as TabPage;
+
+            if (parentControl != null)
+            {
+                parentControl.Text = mFileData.FileName + "*";
+            }
+        }
+
+        /// <summary>
+        /// Called whenever <see cref="Scintilla.SetSavePoint"/> is called,
+        /// i.e. in <see cref="Save"/>
+        /// </summary>
+        /// <param name="sender">-</param>
+        /// <param name="e">-</param>
+        private void textBox_SavePointReached(object sender, EventArgs e)
+        {
+            TabPage parentControl = Parent as TabPage;
+            if (parentControl != null)
+            {
+                parentControl.Text = mFileData.FileName;
             }
         }
     }

--- a/StonehearthEditor/IFileDataSelectable.cs
+++ b/StonehearthEditor/IFileDataSelectable.cs
@@ -1,0 +1,7 @@
+﻿namespace StonehearthEditor
+{
+    public interface IFileDataSelectable
+    {
+        void SetSelectedFileData(FileData file);
+    }
+}

--- a/StonehearthEditor/ManifestView.cs
+++ b/StonehearthEditor/ManifestView.cs
@@ -9,7 +9,7 @@ using Newtonsoft.Json.Linq;
 
 namespace StonehearthEditor
 {
-    public partial class ManifestView : UserControl, IReloadable
+    public partial class ManifestView : UserControl, IReloadable, IFileDataSelectable
     {
         private const int kThumbnailSize = 20;
         private FileData mSelectedFileData = null;

--- a/StonehearthEditor/Module.cs
+++ b/StonehearthEditor/Module.cs
@@ -265,8 +265,11 @@ namespace StonehearthEditor
 
             mModuleFiles.Clear();
 
-            mFileWatcher.EnableRaisingEvents = false;
-            mFileWatcher.Dispose();
+            if (mFileWatcher != null)
+            {
+                mFileWatcher.EnableRaisingEvents = false;
+                mFileWatcher.Dispose();
+            }
         }
 
         private void AddModuleFiles(string fileType)

--- a/StonehearthEditor/StonehearthEditor.csproj
+++ b/StonehearthEditor/StonehearthEditor.csproj
@@ -109,6 +109,10 @@
       <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="ScintillaNET, Version=3.5.6.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\jacobslusser.ScintillaNET.3.5.6\lib\net40\ScintillaNET.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.DirectoryServices" />
@@ -164,6 +168,7 @@
     <Compile Include="FileData.cs" />
     <Compile Include="FolderSelectDialog.cs" />
     <Compile Include="GameMasterNode.cs" />
+    <Compile Include="IFileDataSelectable.cs" />
     <Compile Include="IGraphOwner.cs" />
     <Compile Include="IModuleFileData.cs" />
     <Compile Include="IReloadable.cs" />

--- a/StonehearthEditor/packages.config
+++ b/StonehearthEditor/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="bootstrap" version="3.3.6" targetFramework="net452" />
+  <package id="jacobslusser.ScintillaNET" version="3.5.6" targetFramework="net452" />
   <package id="cef.redist.x64" version="3.2623.1396" targetFramework="net452" />
   <package id="cef.redist.x86" version="3.2623.1396" targetFramework="net452" />
   <package id="CefSharp.Common" version="49.0.0" targetFramework="net452" />


### PR DESCRIPTION
This PR contains integration for [ScintillaNET](https://github.com/jacobslusser/ScintillaNET) to improve the default text editor. It features syntax highlighting and a lexer, which is used for a few features. The current implementation is not making use of all Scintilla features and could be improved in certain areas, but it features everything the normal textbox does and more.

Current features:
- Syntax highlighting for various languages, including lua, JavaScript, JSON, HTML and CSS/LESS.
- Support for CTRL-Clicking on aliases to open their definition file. This also works for `file()` and strings that contain at least a slash and point to a valid file.
- i18n strings are colored in differently and show the translated text as tooltip, like previously.
- Undo, redo and save points

Things that are not present yet to make it an even better experience:
- Auto-indentation on newline
- Support for the Tab key to insert 3 whitespaces
- Undo/Redo maybe could be improved to create smaller undo steps.

ScintillaNET is released under MIT, and [Scintilla's license](http://www.scintilla.org/License.txt) allows free usage as well.

---

While integrating it, I've stumbled across a few code parts that I've had to or wanted to tweak a little as well, so these commits kinda glitched into this one, too.
