### PR TITLE
Removed Any CPU configurations.

### DIFF
--- a/StonehearthEditor.sln
+++ b/StonehearthEditor.sln
@@ -1,4 +1,3 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
 VisualStudioVersion = 14.0.25420.1
@@ -11,34 +10,24 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
 		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
-		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{3891EB63-CA5C-4A02-ACC2-267A1D42FF2B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{3891EB63-CA5C-4A02-ACC2-267A1D42FF2B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3891EB63-CA5C-4A02-ACC2-267A1D42FF2B}.Debug|x64.ActiveCfg = Debug|x64
 		{3891EB63-CA5C-4A02-ACC2-267A1D42FF2B}.Debug|x64.Build.0 = Debug|x64
 		{3891EB63-CA5C-4A02-ACC2-267A1D42FF2B}.Debug|x86.ActiveCfg = Debug|x86
 		{3891EB63-CA5C-4A02-ACC2-267A1D42FF2B}.Debug|x86.Build.0 = Debug|x86
-		{3891EB63-CA5C-4A02-ACC2-267A1D42FF2B}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{3891EB63-CA5C-4A02-ACC2-267A1D42FF2B}.Release|Any CPU.Build.0 = Release|Any CPU
 		{3891EB63-CA5C-4A02-ACC2-267A1D42FF2B}.Release|x64.ActiveCfg = Release|x64
 		{3891EB63-CA5C-4A02-ACC2-267A1D42FF2B}.Release|x64.Build.0 = Release|x64
 		{3891EB63-CA5C-4A02-ACC2-267A1D42FF2B}.Release|x86.ActiveCfg = Release|x86
 		{3891EB63-CA5C-4A02-ACC2-267A1D42FF2B}.Release|x86.Build.0 = Release|x86
-		{43CBC9AA-6A8E-463F-83A9-AFF3124AFDB6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{43CBC9AA-6A8E-463F-83A9-AFF3124AFDB6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{43CBC9AA-6A8E-463F-83A9-AFF3124AFDB6}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{43CBC9AA-6A8E-463F-83A9-AFF3124AFDB6}.Debug|x64.Build.0 = Debug|Any CPU
 		{43CBC9AA-6A8E-463F-83A9-AFF3124AFDB6}.Debug|x86.ActiveCfg = Debug|Any CPU
 		{43CBC9AA-6A8E-463F-83A9-AFF3124AFDB6}.Debug|x86.Build.0 = Debug|Any CPU
-		{43CBC9AA-6A8E-463F-83A9-AFF3124AFDB6}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{43CBC9AA-6A8E-463F-83A9-AFF3124AFDB6}.Release|Any CPU.Build.0 = Release|Any CPU
 		{43CBC9AA-6A8E-463F-83A9-AFF3124AFDB6}.Release|x64.ActiveCfg = Release|Any CPU
 		{43CBC9AA-6A8E-463F-83A9-AFF3124AFDB6}.Release|x64.Build.0 = Release|Any CPU
 		{43CBC9AA-6A8E-463F-83A9-AFF3124AFDB6}.Release|x86.ActiveCfg = Release|Any CPU

--- a/StonehearthEditor/StonehearthEditor.csproj
+++ b/StonehearthEditor/StonehearthEditor.csproj
@@ -32,29 +32,6 @@
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <DocumentationFile>
-    </DocumentationFile>
-    <CodeAnalysisRuleSet>StonehearthEditor.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <CodeAnalysisRuleSet>StonehearthEditor.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\x86\Debug\</OutputPath>


### PR DESCRIPTION
Because CEF does not accept AnyCPU as target platform out of the box, this PR removes it from the _StonehearthEditor_ project and the solution. The _AutocompleteMenu-ScintillaNET_ library stays as AnyCPU as it is, as it doesn't seem to matter there.

According to the description, this might be a fix for #4.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stonehearth/stonehearth-editor/11)
<!-- Reviewable:end -->
