### PR TITLE
Added support for steam_uploads folder. Various fixes.

### DIFF
--- a/StonehearthEditor/App.config
+++ b/StonehearthEditor/App.config
@@ -34,6 +34,9 @@
             <setting name="LastSelectedItemsTypeIndex" serializeAs="String">
                 <value>0</value>
             </setting>
+            <setting name="SteamUploadsDirectory" serializeAs="String">
+                <value />
+            </setting>
         </StonehearthEditor.Properties.Settings>
     </userSettings>
 </configuration>

--- a/StonehearthEditor/CloneObjectParameters.cs
+++ b/StonehearthEditor/CloneObjectParameters.cs
@@ -79,6 +79,9 @@ namespace StonehearthEditor
                 newString = newString.Replace(replacement.Key, replacement.Value);
             }
 
+            // Make sure to replace the mod name too when transforming an alias
+            newString = newString.Replace(SourceModule, TargetModule);
+
             return newString;
         }
 

--- a/StonehearthEditor/Dialogs/AboutDialog.Designer.cs
+++ b/StonehearthEditor/Dialogs/AboutDialog.Designer.cs
@@ -1,0 +1,127 @@
+﻿namespace StonehearthEditor.Dialogs
+{
+    partial class AboutDialog
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.SHEDLabel = new System.Windows.Forms.Label();
+            this.SHEDHomePageLinkLabel = new System.Windows.Forms.LinkLabel();
+            this.SHEDLabel2 = new System.Windows.Forms.Label();
+            this.moddingGuideLabel = new System.Windows.Forms.Label();
+            this.moddingGuideLinkLabel = new System.Windows.Forms.LinkLabel();
+            this.OKbutton = new System.Windows.Forms.Button();
+            this.SuspendLayout();
+            // 
+            // SHEDLabel
+            // 
+            this.SHEDLabel.Location = new System.Drawing.Point(13, 13);
+            this.SHEDLabel.Name = "SHEDLabel";
+            this.SHEDLabel.Size = new System.Drawing.Size(369, 22);
+            this.SHEDLabel.TabIndex = 0;
+            this.SHEDLabel.Text = "SHED is an open source program. You can find it here:";
+            // 
+            // SHEDHomePageLinkLabel
+            // 
+            this.SHEDHomePageLinkLabel.AutoSize = true;
+            this.SHEDHomePageLinkLabel.Location = new System.Drawing.Point(13, 48);
+            this.SHEDHomePageLinkLabel.Name = "SHEDHomePageLinkLabel";
+            this.SHEDHomePageLinkLabel.Size = new System.Drawing.Size(321, 17);
+            this.SHEDHomePageLinkLabel.TabIndex = 1;
+            this.SHEDHomePageLinkLabel.TabStop = true;
+            this.SHEDHomePageLinkLabel.Text = "https://github.com/stonehearth/stonehearth-editor";
+            this.SHEDHomePageLinkLabel.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.SHEDHomePageLinkLabel_LinkClicked);
+            // 
+            // SHEDLabel2
+            // 
+            this.SHEDLabel2.AutoSize = true;
+            this.SHEDLabel2.Location = new System.Drawing.Point(12, 79);
+            this.SHEDLabel2.Name = "SHEDLabel2";
+            this.SHEDLabel2.Size = new System.Drawing.Size(393, 17);
+            this.SHEDLabel2.TabIndex = 2;
+            this.SHEDLabel2.Text = "Feel free to fork the project and improve it for other modders.";
+            // 
+            // moddingGuideLabel
+            // 
+            this.moddingGuideLabel.AutoSize = true;
+            this.moddingGuideLabel.Location = new System.Drawing.Point(12, 119);
+            this.moddingGuideLabel.Name = "moddingGuideLabel";
+            this.moddingGuideLabel.Size = new System.Drawing.Size(321, 17);
+            this.moddingGuideLabel.TabIndex = 3;
+            this.moddingGuideLabel.Text = "Here\'s the official modding guide for Stonehearth:";
+            // 
+            // moddingGuideLinkLabel
+            // 
+            this.moddingGuideLinkLabel.AutoSize = true;
+            this.moddingGuideLinkLabel.Location = new System.Drawing.Point(12, 154);
+            this.moddingGuideLinkLabel.Name = "moddingGuideLinkLabel";
+            this.moddingGuideLinkLabel.Size = new System.Drawing.Size(353, 17);
+            this.moddingGuideLinkLabel.TabIndex = 4;
+            this.moddingGuideLinkLabel.TabStop = true;
+            this.moddingGuideLinkLabel.Text = "https://stonehearth.github.io/modding_guide/index.html";
+            this.moddingGuideLinkLabel.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.moddingGuideLinkLabel_LinkClicked);
+            // 
+            // OKbutton
+            // 
+            this.OKbutton.Location = new System.Drawing.Point(155, 201);
+            this.OKbutton.Name = "OKbutton";
+            this.OKbutton.Size = new System.Drawing.Size(128, 40);
+            this.OKbutton.TabIndex = 5;
+            this.OKbutton.Text = "OK";
+            this.OKbutton.UseVisualStyleBackColor = true;
+            this.OKbutton.Click += new System.EventHandler(this.OKbutton_Click);
+            // 
+            // AboutDialog
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(449, 253);
+            this.Controls.Add(this.OKbutton);
+            this.Controls.Add(this.moddingGuideLinkLabel);
+            this.Controls.Add(this.moddingGuideLabel);
+            this.Controls.Add(this.SHEDLabel2);
+            this.Controls.Add(this.SHEDHomePageLinkLabel);
+            this.Controls.Add(this.SHEDLabel);
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.Name = "AboutDialog";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
+            this.Text = "About Stonehearth Editor";
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Label SHEDLabel;
+        private System.Windows.Forms.LinkLabel SHEDHomePageLinkLabel;
+        private System.Windows.Forms.Label SHEDLabel2;
+        private System.Windows.Forms.Label moddingGuideLabel;
+        private System.Windows.Forms.LinkLabel moddingGuideLinkLabel;
+        private System.Windows.Forms.Button OKbutton;
+    }
+}

--- a/StonehearthEditor/Dialogs/AboutDialog.cs
+++ b/StonehearthEditor/Dialogs/AboutDialog.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace StonehearthEditor.Dialogs
+{
+    public partial class AboutDialog : Form
+    {
+        public AboutDialog()
+        {
+            InitializeComponent();
+        }
+
+        private void SHEDHomePageLinkLabel_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
+        {
+            SHEDHomePageLinkLabel.LinkVisited = true;
+            System.Diagnostics.Process.Start("https://github.com/stonehearth/stonehearth-editor");
+        }
+
+        private void moddingGuideLinkLabel_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
+        {
+            moddingGuideLinkLabel.LinkVisited = true;
+            System.Diagnostics.Process.Start("https://stonehearth.github.io/modding_guide/index.html");
+        }
+
+        private void OKbutton_Click(object sender, EventArgs e)
+        {
+            this.Close();
+        }
+    }
+}

--- a/StonehearthEditor/Dialogs/AboutDialog.resx
+++ b/StonehearthEditor/Dialogs/AboutDialog.resx
@@ -1,0 +1,123 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="$this.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+</root>

--- a/StonehearthEditor/Dialogs/CloneDialog.Designer.cs
+++ b/StonehearthEditor/Dialogs/CloneDialog.Designer.cs
@@ -37,11 +37,11 @@
             this.panel2 = new System.Windows.Forms.Panel();
             this.parametersTable = new System.Windows.Forms.TableLayoutPanel();
             this.panel3 = new System.Windows.Forms.Panel();
-            this.cloneButton = new System.Windows.Forms.Button();
-            this.cloneFromLabel = new System.Windows.Forms.Label();
-            this.sourceModLabel = new System.Windows.Forms.Label();
-            this.cloneToModLabel = new System.Windows.Forms.Label();
             this.modListDropdown = new System.Windows.Forms.ComboBox();
+            this.cloneToModLabel = new System.Windows.Forms.Label();
+            this.sourceModLabel = new System.Windows.Forms.Label();
+            this.cloneFromLabel = new System.Windows.Forms.Label();
+            this.cloneButton = new System.Windows.Forms.Button();
             this.panel1.SuspendLayout();
             this.panel2.SuspendLayout();
             this.parametersTable.SuspendLayout();
@@ -54,7 +54,7 @@
             this.textReplacementsLabel.Dock = System.Windows.Forms.DockStyle.Left;
             this.textReplacementsLabel.Location = new System.Drawing.Point(5, 5);
             this.textReplacementsLabel.Name = "textReplacementsLabel";
-            this.textReplacementsLabel.Size = new System.Drawing.Size(148, 13);
+            this.textReplacementsLabel.Size = new System.Drawing.Size(197, 17);
             this.textReplacementsLabel.TabIndex = 2;
             this.textReplacementsLabel.Text = "Clone this object by replacing:";
             // 
@@ -86,7 +86,7 @@
             this.label3.AutoSize = true;
             this.label3.Location = new System.Drawing.Point(263, 0);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(107, 13);
+            this.label3.Size = new System.Drawing.Size(140, 17);
             this.label3.TabIndex = 6;
             this.label3.Text = "with replacement text";
             // 
@@ -95,7 +95,7 @@
             this.label1.AutoSize = true;
             this.label1.Location = new System.Drawing.Point(3, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(78, 13);
+            this.label1.Size = new System.Drawing.Size(104, 17);
             this.label1.TabIndex = 4;
             this.label1.Text = "original text . . .";
             // 
@@ -141,6 +141,42 @@
             this.panel3.Size = new System.Drawing.Size(520, 35);
             this.panel3.TabIndex = 0;
             // 
+            // modListDropdown
+            // 
+            this.modListDropdown.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.modListDropdown.FormattingEnabled = true;
+            this.modListDropdown.Location = new System.Drawing.Point(304, 8);
+            this.modListDropdown.Name = "modListDropdown";
+            this.modListDropdown.Size = new System.Drawing.Size(130, 24);
+            this.modListDropdown.TabIndex = 4;
+            // 
+            // cloneToModLabel
+            // 
+            this.cloneToModLabel.AutoSize = true;
+            this.cloneToModLabel.Location = new System.Drawing.Point(257, 11);
+            this.cloneToModLabel.Name = "cloneToModLabel";
+            this.cloneToModLabel.Size = new System.Drawing.Size(64, 17);
+            this.cloneToModLabel.TabIndex = 3;
+            this.cloneToModLabel.Text = "Clone to:";
+            // 
+            // sourceModLabel
+            // 
+            this.sourceModLabel.AutoSize = true;
+            this.sourceModLabel.Location = new System.Drawing.Point(67, 11);
+            this.sourceModLabel.Name = "sourceModLabel";
+            this.sourceModLabel.Size = new System.Drawing.Size(86, 17);
+            this.sourceModLabel.TabIndex = 2;
+            this.sourceModLabel.Text = "source_mod";
+            // 
+            // cloneFromLabel
+            // 
+            this.cloneFromLabel.AutoSize = true;
+            this.cloneFromLabel.Location = new System.Drawing.Point(5, 11);
+            this.cloneFromLabel.Name = "cloneFromLabel";
+            this.cloneFromLabel.Size = new System.Drawing.Size(80, 17);
+            this.cloneFromLabel.TabIndex = 1;
+            this.cloneFromLabel.Text = "Clone from:";
+            // 
             // cloneButton
             // 
             this.cloneButton.Dock = System.Windows.Forms.DockStyle.Right;
@@ -151,42 +187,6 @@
             this.cloneButton.Text = "Clone!";
             this.cloneButton.UseVisualStyleBackColor = true;
             this.cloneButton.Click += new System.EventHandler(this.cloneDialogButton_Click);
-            // 
-            // cloneFromLabel
-            // 
-            this.cloneFromLabel.AutoSize = true;
-            this.cloneFromLabel.Location = new System.Drawing.Point(5, 11);
-            this.cloneFromLabel.Name = "cloneFromLabel";
-            this.cloneFromLabel.Size = new System.Drawing.Size(60, 13);
-            this.cloneFromLabel.TabIndex = 1;
-            this.cloneFromLabel.Text = "Clone from:";
-            // 
-            // sourceModLabel
-            // 
-            this.sourceModLabel.AutoSize = true;
-            this.sourceModLabel.Location = new System.Drawing.Point(67, 11);
-            this.sourceModLabel.Name = "sourceModLabel";
-            this.sourceModLabel.Size = new System.Drawing.Size(65, 13);
-            this.sourceModLabel.TabIndex = 2;
-            this.sourceModLabel.Text = "source_mod";
-            // 
-            // cloneToModLabel
-            // 
-            this.cloneToModLabel.AutoSize = true;
-            this.cloneToModLabel.Location = new System.Drawing.Point(257, 11);
-            this.cloneToModLabel.Name = "cloneToModLabel";
-            this.cloneToModLabel.Size = new System.Drawing.Size(49, 13);
-            this.cloneToModLabel.TabIndex = 3;
-            this.cloneToModLabel.Text = "Clone to:";
-            // 
-            // modListDropdown
-            // 
-            this.modListDropdown.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.modListDropdown.FormattingEnabled = true;
-            this.modListDropdown.Location = new System.Drawing.Point(304, 8);
-            this.modListDropdown.Name = "modListDropdown";
-            this.modListDropdown.Size = new System.Drawing.Size(130, 21);
-            this.modListDropdown.TabIndex = 4;
             // 
             // CloneDialog
             // 

--- a/StonehearthEditor/Dialogs/CloneDialog.cs
+++ b/StonehearthEditor/Dialogs/CloneDialog.cs
@@ -15,12 +15,19 @@ namespace StonehearthEditor
 
         private IDialogCallback mCallback;
 
-        public CloneDialog(string clonedObjectName, string initialText)
+        public CloneDialog(string clonedObjectName, string initialText, string sourceMod)
         {
             InitializeComponent();
             Text = "Clone: " + clonedObjectName;
 
-            FillModListDropdown(clonedObjectName);
+            if (sourceMod != String.Empty)
+            {
+                FillModListDropdown(sourceMod);
+            }
+            else
+            {
+                FillModListDropdown(clonedObjectName);
+            }
 
             int index = clonedObjectName.IndexOf(':');
             if (index != -1 && clonedObjectName.Length > index)
@@ -34,7 +41,7 @@ namespace StonehearthEditor
                 }
             }
 
-            sourceModLabel.Text = clonedObjectName.Split(':')[0];
+            sourceModLabel.Text = sourceMod != String.Empty ? sourceMod : clonedObjectName.Split(':')[0];
 
             AddNewRow(initialText);
             AcceptButton = cloneButton;

--- a/StonehearthEditor/Dialogs/ModDirectorySettingsDialog.Designer.cs
+++ b/StonehearthEditor/Dialogs/ModDirectorySettingsDialog.Designer.cs
@@ -1,0 +1,131 @@
+﻿namespace StonehearthEditor
+{
+    partial class ModDirectorySettingsDialog
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.baseModsLabel = new System.Windows.Forms.Label();
+            this.baseModsPathTextbox = new System.Windows.Forms.TextBox();
+            this.changeBaseModsPathButton = new System.Windows.Forms.Button();
+            this.steamUploadsPathLabel = new System.Windows.Forms.Label();
+            this.steamUploadsPathTextbox = new System.Windows.Forms.TextBox();
+            this.changeSteamUploadsPathButton = new System.Windows.Forms.Button();
+            this.applyButton = new System.Windows.Forms.Button();
+            this.SuspendLayout();
+            // 
+            // baseModsLabel
+            // 
+            this.baseModsLabel.AutoSize = true;
+            this.baseModsLabel.Location = new System.Drawing.Point(13, 13);
+            this.baseModsLabel.Name = "baseModsLabel";
+            this.baseModsLabel.Size = new System.Drawing.Size(371, 17);
+            this.baseModsLabel.TabIndex = 0;
+            this.baseModsLabel.Text = "Base mods root directory (where the stonehearth mod is):";
+            // 
+            // baseModsPathTextbox
+            // 
+            this.baseModsPathTextbox.Location = new System.Drawing.Point(16, 34);
+            this.baseModsPathTextbox.Name = "baseModsPathTextbox";
+            this.baseModsPathTextbox.Size = new System.Drawing.Size(452, 22);
+            this.baseModsPathTextbox.TabIndex = 1;
+            // 
+            // changeBaseModsPathButton
+            // 
+            this.changeBaseModsPathButton.Location = new System.Drawing.Point(474, 30);
+            this.changeBaseModsPathButton.Name = "changeBaseModsPathButton";
+            this.changeBaseModsPathButton.Size = new System.Drawing.Size(120, 30);
+            this.changeBaseModsPathButton.TabIndex = 2;
+            this.changeBaseModsPathButton.Text = "Browse...";
+            this.changeBaseModsPathButton.UseVisualStyleBackColor = true;
+            this.changeBaseModsPathButton.Click += new System.EventHandler(this.changeBaseModsPathButton_Click);
+            // 
+            // steamUploadsPathLabel
+            // 
+            this.steamUploadsPathLabel.AutoSize = true;
+            this.steamUploadsPathLabel.Location = new System.Drawing.Point(13, 84);
+            this.steamUploadsPathLabel.Name = "steamUploadsPathLabel";
+            this.steamUploadsPathLabel.Size = new System.Drawing.Size(309, 17);
+            this.steamUploadsPathLabel.TabIndex = 3;
+            this.steamUploadsPathLabel.Text = "Additional mods directory (e.g. steam_uploads):";
+            // 
+            // steamUploadsPathTextbox
+            // 
+            this.steamUploadsPathTextbox.Location = new System.Drawing.Point(16, 109);
+            this.steamUploadsPathTextbox.Name = "steamUploadsPathTextbox";
+            this.steamUploadsPathTextbox.Size = new System.Drawing.Size(452, 22);
+            this.steamUploadsPathTextbox.TabIndex = 4;
+            // 
+            // changeSteamUploadsPathButton
+            // 
+            this.changeSteamUploadsPathButton.Location = new System.Drawing.Point(474, 104);
+            this.changeSteamUploadsPathButton.Name = "changeSteamUploadsPathButton";
+            this.changeSteamUploadsPathButton.Size = new System.Drawing.Size(120, 32);
+            this.changeSteamUploadsPathButton.TabIndex = 5;
+            this.changeSteamUploadsPathButton.Text = "Browse...";
+            this.changeSteamUploadsPathButton.UseVisualStyleBackColor = true;
+            this.changeSteamUploadsPathButton.Click += new System.EventHandler(this.changeSteamUploadsPathButton_Click);
+            // 
+            // applyButton
+            // 
+            this.applyButton.Location = new System.Drawing.Point(402, 182);
+            this.applyButton.Name = "applyButton";
+            this.applyButton.Size = new System.Drawing.Size(215, 34);
+            this.applyButton.TabIndex = 6;
+            this.applyButton.Text = "Apply and reload";
+            this.applyButton.UseVisualStyleBackColor = true;
+            this.applyButton.Click += new System.EventHandler(this.applyButton_Click);
+            // 
+            // ModDirectorySettingsDialog
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(629, 228);
+            this.Controls.Add(this.applyButton);
+            this.Controls.Add(this.changeSteamUploadsPathButton);
+            this.Controls.Add(this.steamUploadsPathTextbox);
+            this.Controls.Add(this.steamUploadsPathLabel);
+            this.Controls.Add(this.changeBaseModsPathButton);
+            this.Controls.Add(this.baseModsPathTextbox);
+            this.Controls.Add(this.baseModsLabel);
+            this.Name = "ModDirectorySettingsDialog";
+            this.Text = "Mods directories";
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Label baseModsLabel;
+        private System.Windows.Forms.TextBox baseModsPathTextbox;
+        private System.Windows.Forms.Button changeBaseModsPathButton;
+        private System.Windows.Forms.Label steamUploadsPathLabel;
+        private System.Windows.Forms.TextBox steamUploadsPathTextbox;
+        private System.Windows.Forms.Button changeSteamUploadsPathButton;
+        private System.Windows.Forms.Button applyButton;
+    }
+}

--- a/StonehearthEditor/Dialogs/ModDirectorySettingsDialog.cs
+++ b/StonehearthEditor/Dialogs/ModDirectorySettingsDialog.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Windows.Forms;
+
+namespace StonehearthEditor
+{
+    public partial class ModDirectorySettingsDialog : Form
+    {
+        public interface IDialogCallback
+        {
+            // Returns true if we can close the dialog
+            bool OnAccept(string baseModsPath, string steamUploadsPath);
+
+            void OnCancelled();
+        }
+
+        private IDialogCallback mCallback;
+
+        public ModDirectorySettingsDialog(string baseModsPath, string steamUploadsPath)
+        {
+            InitializeComponent();
+
+            if (baseModsPath != null)
+            {
+                baseModsPathTextbox.Text = baseModsPath;
+            }
+
+            if (steamUploadsPath != null)
+            {
+                steamUploadsPathTextbox.Text = steamUploadsPath;
+            }
+        }
+
+        public void SetCallback(IDialogCallback callback)
+        {
+            mCallback = callback;
+        }
+
+        private void changeBaseModsPathButton_Click(object sender, EventArgs e)
+        {
+            var dialog = new FolderSelectDialog()
+            {
+                DirectoryPath = baseModsPathTextbox.Text ?? Environment.CurrentDirectory,
+                Title = "Stonehearth Mods Root Directory"
+            };
+
+            DialogResult result = DialogResult.Abort;
+
+            result = dialog.ShowDialog();
+
+            if (result == DialogResult.OK)
+            {
+                baseModsPathTextbox.Text = dialog.DirectoryPath;
+            }
+        }
+
+        private void changeSteamUploadsPathButton_Click(object sender, EventArgs e)
+        {
+            var dialog = new FolderSelectDialog()
+            {
+                DirectoryPath = steamUploadsPathTextbox.Text ?? Environment.CurrentDirectory,
+                Title = "Steam Uploads Directory"
+            };
+
+            DialogResult result = DialogResult.Abort;
+
+            result = dialog.ShowDialog();
+
+            if (result == DialogResult.OK)
+            {
+                steamUploadsPathTextbox.Text = dialog.DirectoryPath;
+            }
+        }
+
+        private void applyButton_Click(object sender, EventArgs e)
+        {
+            if (mCallback != null)
+            {
+                bool isSuccess = mCallback.OnAccept(baseModsPathTextbox.Text, steamUploadsPathTextbox.Text);
+                if (isSuccess)
+                {
+                    mCallback = null;
+                    this.DialogResult = DialogResult.OK;
+                    Close();
+                }
+            }
+        }
+    }
+}

--- a/StonehearthEditor/Dialogs/ModDirectorySettingsDialog.resx
+++ b/StonehearthEditor/Dialogs/ModDirectorySettingsDialog.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/StonehearthEditor/Dialogs/PreviewCloneDialog.Designer.cs
+++ b/StonehearthEditor/Dialogs/PreviewCloneDialog.Designer.cs
@@ -28,99 +28,119 @@
       /// </summary>
       private void InitializeComponent()
       {
-         this.dependenciesListBox = new System.Windows.Forms.CheckedListBox();
-         this.label1 = new System.Windows.Forms.Label();
-         this.panel1 = new System.Windows.Forms.Panel();
-         this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
-         this.acceptButton = new System.Windows.Forms.Button();
-         this.cancelButton = new System.Windows.Forms.Button();
-         this.panel1.SuspendLayout();
-         this.flowLayoutPanel1.SuspendLayout();
-         this.SuspendLayout();
-         // 
-         // dependenciesListBox
-         // 
-         this.dependenciesListBox.CheckOnClick = true;
-         this.dependenciesListBox.Dock = System.Windows.Forms.DockStyle.Fill;
-         this.dependenciesListBox.FormattingEnabled = true;
-         this.dependenciesListBox.Location = new System.Drawing.Point(10, 10);
-         this.dependenciesListBox.Margin = new System.Windows.Forms.Padding(10);
-         this.dependenciesListBox.Name = "dependenciesListBox";
-         this.dependenciesListBox.Size = new System.Drawing.Size(668, 264);
-         this.dependenciesListBox.TabIndex = 0;
-         // 
-         // label1
-         // 
-         this.label1.AutoSize = true;
-         this.label1.Dock = System.Windows.Forms.DockStyle.Top;
-         this.label1.Location = new System.Drawing.Point(0, 0);
-         this.label1.Margin = new System.Windows.Forms.Padding(3, 20, 3, 0);
-         this.label1.Name = "label1";
-         this.label1.Padding = new System.Windows.Forms.Padding(10);
-         this.label1.Size = new System.Drawing.Size(185, 33);
-         this.label1.TabIndex = 1;
-         this.label1.Text = "The following files will be created:";
-         // 
-         // panel1
-         // 
-         this.panel1.Controls.Add(this.dependenciesListBox);
-         this.panel1.Dock = System.Windows.Forms.DockStyle.Fill;
-         this.panel1.Location = new System.Drawing.Point(0, 33);
-         this.panel1.Name = "panel1";
-         this.panel1.Padding = new System.Windows.Forms.Padding(10);
-         this.panel1.Size = new System.Drawing.Size(688, 284);
-         this.panel1.TabIndex = 2;
-         // 
-         // flowLayoutPanel1
-         // 
-         this.flowLayoutPanel1.Controls.Add(this.acceptButton);
-         this.flowLayoutPanel1.Controls.Add(this.cancelButton);
-         this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Bottom;
-         this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.RightToLeft;
-         this.flowLayoutPanel1.Location = new System.Drawing.Point(0, 317);
-         this.flowLayoutPanel1.Name = "flowLayoutPanel1";
-         this.flowLayoutPanel1.Size = new System.Drawing.Size(688, 31);
-         this.flowLayoutPanel1.TabIndex = 1;
-         // 
-         // acceptButton
-         // 
-         this.acceptButton.Location = new System.Drawing.Point(610, 3);
-         this.acceptButton.Name = "acceptButton";
-         this.acceptButton.Size = new System.Drawing.Size(75, 23);
-         this.acceptButton.TabIndex = 0;
-         this.acceptButton.Text = "Accept";
-         this.acceptButton.UseVisualStyleBackColor = true;
-         this.acceptButton.Click += new System.EventHandler(this.acceptButton_Click);
-         // 
-         // cancelButton
-         // 
-         this.cancelButton.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-         this.cancelButton.Location = new System.Drawing.Point(529, 3);
-         this.cancelButton.Name = "cancelButton";
-         this.cancelButton.Size = new System.Drawing.Size(75, 23);
-         this.cancelButton.TabIndex = 1;
-         this.cancelButton.Text = "Cancel";
-         this.cancelButton.UseVisualStyleBackColor = true;
-         this.cancelButton.Click += new System.EventHandler(this.cancelButton_Click);
-         // 
-         // PreviewCloneDialog
-         // 
-         this.AcceptButton = this.acceptButton;
-         this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-         this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-         this.CancelButton = this.cancelButton;
-         this.ClientSize = new System.Drawing.Size(688, 348);
-         this.Controls.Add(this.panel1);
-         this.Controls.Add(this.label1);
-         this.Controls.Add(this.flowLayoutPanel1);
-         this.KeyPreview = true;
-         this.Name = "PreviewCloneDialog";
-         this.Text = "Clone Preview";
-         this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.PreviewCloneDialog_FormClosed);
-         this.panel1.ResumeLayout(false);
-         this.flowLayoutPanel1.ResumeLayout(false);
-         this.ResumeLayout(false);
-         this.PerformLayout();
+            this.dependenciesListBox = new System.Windows.Forms.CheckedListBox();
+            this.label1 = new System.Windows.Forms.Label();
+            this.panel1 = new System.Windows.Forms.Panel();
+            this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
+            this.acceptButton = new System.Windows.Forms.Button();
+            this.cancelButton = new System.Windows.Forms.Button();
+            this.checkAllCheckbox = new System.Windows.Forms.CheckBox();
+            this.panel1.SuspendLayout();
+            this.flowLayoutPanel1.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // dependenciesListBox
+            // 
+            this.dependenciesListBox.CheckOnClick = true;
+            this.dependenciesListBox.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.dependenciesListBox.FormattingEnabled = true;
+            this.dependenciesListBox.Location = new System.Drawing.Point(13, 12);
+            this.dependenciesListBox.Margin = new System.Windows.Forms.Padding(13, 12, 13, 12);
+            this.dependenciesListBox.Name = "dependenciesListBox";
+            this.dependenciesListBox.Size = new System.Drawing.Size(891, 340);
+            this.dependenciesListBox.TabIndex = 0;
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Dock = System.Windows.Forms.DockStyle.Top;
+            this.label1.Location = new System.Drawing.Point(0, 0);
+            this.label1.Margin = new System.Windows.Forms.Padding(4, 25, 4, 0);
+            this.label1.Name = "label1";
+            this.label1.Padding = new System.Windows.Forms.Padding(13, 12, 13, 12);
+            this.label1.Size = new System.Drawing.Size(244, 41);
+            this.label1.TabIndex = 1;
+            this.label1.Text = "The following files will be created:";
+            // 
+            // panel1
+            // 
+            this.panel1.Controls.Add(this.dependenciesListBox);
+            this.panel1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.panel1.Location = new System.Drawing.Point(0, 41);
+            this.panel1.Margin = new System.Windows.Forms.Padding(4);
+            this.panel1.Name = "panel1";
+            this.panel1.Padding = new System.Windows.Forms.Padding(13, 12, 13, 12);
+            this.panel1.Size = new System.Drawing.Size(917, 364);
+            this.panel1.TabIndex = 2;
+            // 
+            // flowLayoutPanel1
+            // 
+            this.flowLayoutPanel1.Controls.Add(this.acceptButton);
+            this.flowLayoutPanel1.Controls.Add(this.cancelButton);
+            this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Bottom;
+            this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.RightToLeft;
+            this.flowLayoutPanel1.Location = new System.Drawing.Point(0, 405);
+            this.flowLayoutPanel1.Margin = new System.Windows.Forms.Padding(4);
+            this.flowLayoutPanel1.Name = "flowLayoutPanel1";
+            this.flowLayoutPanel1.Size = new System.Drawing.Size(917, 38);
+            this.flowLayoutPanel1.TabIndex = 1;
+            // 
+            // acceptButton
+            // 
+            this.acceptButton.Location = new System.Drawing.Point(813, 4);
+            this.acceptButton.Margin = new System.Windows.Forms.Padding(4);
+            this.acceptButton.Name = "acceptButton";
+            this.acceptButton.Size = new System.Drawing.Size(100, 28);
+            this.acceptButton.TabIndex = 0;
+            this.acceptButton.Text = "Accept";
+            this.acceptButton.UseVisualStyleBackColor = true;
+            this.acceptButton.Click += new System.EventHandler(this.acceptButton_Click);
+            // 
+            // cancelButton
+            // 
+            this.cancelButton.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.cancelButton.Location = new System.Drawing.Point(705, 4);
+            this.cancelButton.Margin = new System.Windows.Forms.Padding(4);
+            this.cancelButton.Name = "cancelButton";
+            this.cancelButton.Size = new System.Drawing.Size(100, 28);
+            this.cancelButton.TabIndex = 1;
+            this.cancelButton.Text = "Cancel";
+            this.cancelButton.UseVisualStyleBackColor = true;
+            this.cancelButton.Click += new System.EventHandler(this.cancelButton_Click);
+            // 
+            // checkAllCheckbox
+            // 
+            this.checkAllCheckbox.AutoSize = true;
+            this.checkAllCheckbox.Checked = true;
+            this.checkAllCheckbox.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.checkAllCheckbox.Location = new System.Drawing.Point(13, 31);
+            this.checkAllCheckbox.Name = "checkAllCheckbox";
+            this.checkAllCheckbox.Size = new System.Drawing.Size(147, 21);
+            this.checkAllCheckbox.TabIndex = 3;
+            this.checkAllCheckbox.Text = "Check/Uncheck All";
+            this.checkAllCheckbox.UseVisualStyleBackColor = true;
+            this.checkAllCheckbox.CheckedChanged += new System.EventHandler(this.checkAllCheckbox_CheckedChanged);
+            // 
+            // PreviewCloneDialog
+            // 
+            this.AcceptButton = this.acceptButton;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.CancelButton = this.cancelButton;
+            this.ClientSize = new System.Drawing.Size(917, 443);
+            this.Controls.Add(this.checkAllCheckbox);
+            this.Controls.Add(this.panel1);
+            this.Controls.Add(this.label1);
+            this.Controls.Add(this.flowLayoutPanel1);
+            this.KeyPreview = true;
+            this.Margin = new System.Windows.Forms.Padding(4);
+            this.Name = "PreviewCloneDialog";
+            this.Text = "Clone Preview";
+            this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.PreviewCloneDialog_FormClosed);
+            this.panel1.ResumeLayout(false);
+            this.flowLayoutPanel1.ResumeLayout(false);
+            this.ResumeLayout(false);
+            this.PerformLayout();
 
       }
 
@@ -132,5 +152,6 @@
       private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel1;
       private System.Windows.Forms.Button acceptButton;
       private System.Windows.Forms.Button cancelButton;
-   }
+        private System.Windows.Forms.CheckBox checkAllCheckbox;
+    }
 }

--- a/StonehearthEditor/Dialogs/PreviewCloneDialog.cs
+++ b/StonehearthEditor/Dialogs/PreviewCloneDialog.cs
@@ -78,5 +78,15 @@ namespace StonehearthEditor
                 mCallback = null;
             }
         }
+
+        private void checkAllCheckbox_CheckedChanged(object sender, EventArgs e)
+        {
+            bool checkStatus = checkAllCheckbox.Checked; // This is the current status after checked changed
+
+            for (int i = 0; i < dependenciesListBox.Items.Count; i++)
+            {
+                dependenciesListBox.SetItemChecked(i, checkStatus);
+            }
+        }
     }
 }

--- a/StonehearthEditor/EffectsEditorView.cs
+++ b/StonehearthEditor/EffectsEditorView.cs
@@ -329,6 +329,8 @@ namespace StonehearthEditor
                 case 1:
                     return lightsTreeView;
                 case 2:
+                    return effectsEditorTreeView;
+                case 3:
                     return skySettingsTreeView;
                 default:
                     return effectsEditorTreeView;
@@ -348,8 +350,16 @@ namespace StonehearthEditor
             }
 
             FileData selectedFileData = GetFileDataFromPath(filePath);
+            char separator = '\\';
+            if (!selectedNode.FullPath.Contains('\\'))
+            {
+                // For cubemitters the paths were being retrieved as filepaths, not nodepaths
+                // so do this to retrieve the source mod name correctly
+                separator = '/';
+            }
+            string sourceModName = selectedNode.FullPath.Split(separator)[0];
             CloneEffectFileCallback callback = new CloneEffectFileCallback(this, selectedFileData);
-            CloneDialog dialog = new CloneDialog(selectedFileData.FileName, selectedFileData.GetNameForCloning());
+            CloneDialog dialog = new CloneDialog(selectedFileData.FileName, selectedFileData.GetNameForCloning(), sourceModName);
             dialog.SetCallback(callback);
             dialog.ShowDialog();
         }

--- a/StonehearthEditor/FileData/FileData.cs
+++ b/StonehearthEditor/FileData/FileData.cs
@@ -204,7 +204,7 @@ namespace StonehearthEditor
             {
                 string dependencyName = dependencyKV.Key;
                 FileData dependencyFile = dependencyKV.Value;
-                if (ShouldCloneDependency(dependencyName, parameters))
+                if (dependencyFile != null && ShouldCloneDependency(dependencyName, parameters))
                 {
                     // We want to clone this dependency
                     IModuleFileData modFileData = dependencyFile as IModuleFileData;
@@ -223,8 +223,7 @@ namespace StonehearthEditor
                     {
                         // This dependency is just a FileData, clone the fileData.
                         string transformedDependencyName = parameters.TransformModPath(dependencyName);
-                        string linkedPath = ModuleDataManager.GetInstance().ModsDirectoryPath + transformedDependencyName;
-                        string newDependencyPath = ModuleDataManager.GetInstance().ModsDirectoryPath + parameters.TransformParameter(transformedDependencyName);
+                        string newDependencyPath = ModuleDataManager.GetInstance().GetMod(parameters.TargetModule).ParentDirectory + parameters.TransformParameter(transformedDependencyName);
                         if (!alreadyCloned.Contains(newDependencyPath))
                         {
                             alreadyCloned.Add(newDependencyPath);
@@ -279,7 +278,8 @@ namespace StonehearthEditor
 
             foreach (KeyValuePair<string, FileData> file in LinkedFileData)
             {
-                string filePathWithoutBase = file.Key.Replace(ModuleDataManager.GetInstance().ModsDirectoryPath, "");
+                string filePathWithoutBase = ModuleDataManager.GetInstance().TryReplaceModsDirectory(file.Key, "", "");
+                filePathWithoutBase = ModuleDataManager.GetInstance().TryReplaceSteamUploadsDirectory(filePathWithoutBase, "", "");
                 if (!dependencies.ContainsKey(filePathWithoutBase))
                 {
                     dependencies.Add(filePathWithoutBase, file.Value);

--- a/StonehearthEditor/FilePreview.cs
+++ b/StonehearthEditor/FilePreview.cs
@@ -84,7 +84,16 @@ namespace StonehearthEditor
             this.configureScintilla();
 
             localizeFile.Visible = textBox.Lexer == ScintillaNET.Lexer.Json;
-            previewMixinsButton.Visible = (textBox.Lexer == ScintillaNET.Lexer.Json) && (mFileData as JsonFileData)?.Json.SelectToken("mixins") != null;
+            bool hasMixins = false;
+            if ((mFileData as JsonFileData) != null)
+            {
+                if ((mFileData as JsonFileData).Json != null)
+                {
+                    hasMixins = (mFileData as JsonFileData).Json.SelectToken("mixins") != null;
+                }
+            }
+
+            previewMixinsButton.Visible = (textBox.Lexer == ScintillaNET.Lexer.Json) && hasMixins;
         }
 
         /// <summary> 
@@ -335,7 +344,10 @@ namespace StonehearthEditor
             string generateLocPythonFile = Application.StartupPath + "/scripts/generate_loc_keys.py";
             start.FileName = generateLocPythonFile;
             string filePath = mFileData.Path;
-            string modsRoot = ModuleDataManager.GetInstance().ModsDirectoryPath;
+            string modName = ModuleDataManager.GetInstance().TryReplaceModsDirectory(mFileData.Path, "", "");
+            modName = ModuleDataManager.GetInstance().TryReplaceSteamUploadsDirectory(modName, "", "");
+            modName = modName.Split('/')[1];
+            string modsRoot = ModuleDataManager.GetInstance().GetParentDirectoryByModName(modName);
             start.Arguments = string.Format("-r {0} {1}", modsRoot, filePath);
             ////MessageBox.Show("executing command: " + generateLocPythonFile + " -r " + modsRoot + " " + filePath);
 

--- a/StonehearthEditor/JsonHelper.cs
+++ b/StonehearthEditor/JsonHelper.cs
@@ -189,18 +189,25 @@ namespace StonehearthEditor
             {
                 if (startedWithFile)
                 {
-                    string mod = parentPath.Replace(MainForm.kModsDirectoryPath + '/', "");
+                    // We don't know where the mod is, so replace both directories just in case
+                    string mod = ModuleDataManager.GetInstance().TryReplaceModsDirectory(parentPath, "", "/");
+                    mod = ModuleDataManager.GetInstance().TryReplaceSteamUploadsDirectory(mod, "", "/");
                     int firstSlash = mod.IndexOf('/');
                     if (firstSlash >= 0)
                     {
                         mod = mod.Substring(0, firstSlash);
                     }
 
-                    fullPath = ModuleDataManager.GetInstance().ModsDirectoryPath + '/' + mod + fullPath;
+                    fullPath = ModuleDataManager.GetInstance().GetParentDirectoryByModName(mod) + '/' + mod + fullPath;
                 }
                 else
                 {
-                    fullPath = ModuleDataManager.GetInstance().ModsDirectoryPath + fullPath;
+                    // This is likely a recipe or similar. Assume the first word is the mod namespace
+                    string mod = fullPath;
+                    mod = mod.Substring(1); // Remove the first slash
+                    int firstSlash = mod.IndexOf('/');
+                    mod = mod.Substring(0, firstSlash);
+                    fullPath = ModuleDataManager.GetInstance().GetParentDirectoryByModName(mod) + fullPath;
                 }
             }
             else

--- a/StonehearthEditor/MainForm.Designer.cs
+++ b/StonehearthEditor/MainForm.Designer.cs
@@ -33,10 +33,15 @@ namespace StonehearthEditor
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(MainForm));
             this.tabControl = new System.Windows.Forms.TabControl();
             this.manifestTab = new System.Windows.Forms.TabPage();
+            this.manifestView = new StonehearthEditor.ManifestView();
             this.encounterTab = new System.Windows.Forms.TabPage();
+            this.encounterDesignerView = new StonehearthEditor.EncounterDesignerView();
             this.entityBrowserTab = new System.Windows.Forms.TabPage();
+            this.entityBrowserView = new StonehearthEditor.EntityBrowserView();
             this.effectsEditorTab = new System.Windows.Forms.TabPage();
+            this.effectsEditorView = new StonehearthEditor.EffectsEditorView();
             this.recipesTab = new System.Windows.Forms.TabPage();
+            this.recipesView = new StonehearthEditor.Recipes.RecipesView();
             this.saveToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.mainFormMenu = new System.Windows.Forms.MenuStrip();
             this.fileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -46,11 +51,8 @@ namespace StonehearthEditor
             this.changeModDirectoryToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.viewToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.netWorthVisualizerToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.manifestView = new StonehearthEditor.ManifestView();
-            this.encounterDesignerView = new StonehearthEditor.EncounterDesignerView();
-            this.entityBrowserView = new StonehearthEditor.EntityBrowserView();
-            this.effectsEditorView = new StonehearthEditor.EffectsEditorView();
-            this.recipesView = new StonehearthEditor.Recipes.RecipesView();
+            this.helpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.aboutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.tabControl.SuspendLayout();
             this.manifestTab.SuspendLayout();
             this.encounterTab.SuspendLayout();
@@ -86,6 +88,15 @@ namespace StonehearthEditor
             this.manifestTab.Text = "Manifest";
             this.manifestTab.UseVisualStyleBackColor = true;
             // 
+            // manifestView
+            // 
+            this.manifestView.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.manifestView.Location = new System.Drawing.Point(3, 3);
+            this.manifestView.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.manifestView.Name = "manifestView";
+            this.manifestView.Size = new System.Drawing.Size(1109, 542);
+            this.manifestView.TabIndex = 0;
+            // 
             // encounterTab
             // 
             this.encounterTab.Controls.Add(this.encounterDesignerView);
@@ -96,6 +107,15 @@ namespace StonehearthEditor
             this.encounterTab.TabIndex = 1;
             this.encounterTab.Text = "Encounter Designer";
             this.encounterTab.UseVisualStyleBackColor = true;
+            // 
+            // encounterDesignerView
+            // 
+            this.encounterDesignerView.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.encounterDesignerView.Location = new System.Drawing.Point(3, 3);
+            this.encounterDesignerView.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.encounterDesignerView.Name = "encounterDesignerView";
+            this.encounterDesignerView.Size = new System.Drawing.Size(1109, 542);
+            this.encounterDesignerView.TabIndex = 0;
             // 
             // entityBrowserTab
             // 
@@ -108,6 +128,15 @@ namespace StonehearthEditor
             this.entityBrowserTab.Text = "Entity Stats Browser";
             this.entityBrowserTab.UseVisualStyleBackColor = true;
             // 
+            // entityBrowserView
+            // 
+            this.entityBrowserView.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.entityBrowserView.Location = new System.Drawing.Point(3, 3);
+            this.entityBrowserView.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.entityBrowserView.Name = "entityBrowserView";
+            this.entityBrowserView.Size = new System.Drawing.Size(1109, 542);
+            this.entityBrowserView.TabIndex = 0;
+            // 
             // effectsEditorTab
             // 
             this.effectsEditorTab.Controls.Add(this.effectsEditorView);
@@ -118,6 +147,15 @@ namespace StonehearthEditor
             this.effectsEditorTab.TabIndex = 3;
             this.effectsEditorTab.Text = "Effects Editor";
             this.effectsEditorTab.UseVisualStyleBackColor = true;
+            // 
+            // effectsEditorView
+            // 
+            this.effectsEditorView.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.effectsEditorView.Location = new System.Drawing.Point(3, 3);
+            this.effectsEditorView.Margin = new System.Windows.Forms.Padding(4);
+            this.effectsEditorView.Name = "effectsEditorView";
+            this.effectsEditorView.Size = new System.Drawing.Size(1109, 542);
+            this.effectsEditorView.TabIndex = 0;
             // 
             // recipesTab
             // 
@@ -130,6 +168,16 @@ namespace StonehearthEditor
             this.recipesTab.Text = "Recipe Editor";
             this.recipesTab.UseVisualStyleBackColor = true;
             // 
+            // recipesView
+            // 
+            this.recipesView.AutoSize = true;
+            this.recipesView.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.recipesView.Location = new System.Drawing.Point(3, 3);
+            this.recipesView.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.recipesView.Name = "recipesView";
+            this.recipesView.Size = new System.Drawing.Size(1109, 542);
+            this.recipesView.TabIndex = 0;
+            // 
             // saveToolStripMenuItem
             // 
             this.saveToolStripMenuItem.Name = "saveToolStripMenuItem";
@@ -140,7 +188,8 @@ namespace StonehearthEditor
             this.mainFormMenu.ImageScalingSize = new System.Drawing.Size(20, 20);
             this.mainFormMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.fileToolStripMenuItem,
-            this.viewToolStripMenuItem});
+            this.viewToolStripMenuItem,
+            this.helpToolStripMenuItem});
             this.mainFormMenu.Location = new System.Drawing.Point(0, 0);
             this.mainFormMenu.Name = "mainFormMenu";
             this.mainFormMenu.Size = new System.Drawing.Size(1123, 28);
@@ -206,51 +255,20 @@ namespace StonehearthEditor
             this.netWorthVisualizerToolStripMenuItem.Text = "Net Worth Visualizer";
             this.netWorthVisualizerToolStripMenuItem.Click += new System.EventHandler(this.netWorthVisualizerToolStripMenuItem_Click);
             // 
-            // manifestView
+            // helpToolStripMenuItem
             // 
-            this.manifestView.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.manifestView.Location = new System.Drawing.Point(3, 3);
-            this.manifestView.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.manifestView.Name = "manifestView";
-            this.manifestView.Size = new System.Drawing.Size(1109, 542);
-            this.manifestView.TabIndex = 0;
+            this.helpToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.aboutToolStripMenuItem});
+            this.helpToolStripMenuItem.Name = "helpToolStripMenuItem";
+            this.helpToolStripMenuItem.Size = new System.Drawing.Size(53, 24);
+            this.helpToolStripMenuItem.Text = "Help";
             // 
-            // encounterDesignerView
+            // aboutToolStripMenuItem
             // 
-            this.encounterDesignerView.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.encounterDesignerView.Location = new System.Drawing.Point(3, 3);
-            this.encounterDesignerView.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.encounterDesignerView.Name = "encounterDesignerView";
-            this.encounterDesignerView.Size = new System.Drawing.Size(1109, 542);
-            this.encounterDesignerView.TabIndex = 0;
-            // 
-            // entityBrowserView
-            // 
-            this.entityBrowserView.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.entityBrowserView.Location = new System.Drawing.Point(3, 3);
-            this.entityBrowserView.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.entityBrowserView.Name = "entityBrowserView";
-            this.entityBrowserView.Size = new System.Drawing.Size(1109, 542);
-            this.entityBrowserView.TabIndex = 0;
-            // 
-            // effectsEditorView
-            // 
-            this.effectsEditorView.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.effectsEditorView.Location = new System.Drawing.Point(3, 3);
-            this.effectsEditorView.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.effectsEditorView.Name = "effectsEditorView";
-            this.effectsEditorView.Size = new System.Drawing.Size(1109, 542);
-            this.effectsEditorView.TabIndex = 0;
-            // 
-            // recipesView
-            // 
-            this.recipesView.AutoSize = true;
-            this.recipesView.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.recipesView.Location = new System.Drawing.Point(3, 3);
-            this.recipesView.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.recipesView.Name = "recipesView";
-            this.recipesView.Size = new System.Drawing.Size(1109, 542);
-            this.recipesView.TabIndex = 0;
+            this.aboutToolStripMenuItem.Name = "aboutToolStripMenuItem";
+            this.aboutToolStripMenuItem.Size = new System.Drawing.Size(181, 26);
+            this.aboutToolStripMenuItem.Text = "About";
+            this.aboutToolStripMenuItem.Click += new System.EventHandler(this.aboutToolStripMenuItem_Click);
             // 
             // MainForm
             // 
@@ -304,5 +322,7 @@ namespace StonehearthEditor
         private EffectsEditorView effectsEditorView;
         private System.Windows.Forms.TabPage recipesTab;
         private RecipesView recipesView;
+        private System.Windows.Forms.ToolStripMenuItem helpToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem aboutToolStripMenuItem;
     }
 }

--- a/StonehearthEditor/ManifestView.cs
+++ b/StonehearthEditor/ManifestView.cs
@@ -24,7 +24,7 @@ namespace StonehearthEditor
         public void Initialize()
         {
             ThumbnailCache.ClearCache();
-            new ModuleDataManager(MainForm.kModsDirectoryPath);
+            new ModuleDataManager(MainForm.kModsDirectoryPath, MainForm.kSteamUploadsDirectoryPath);
             ModuleDataManager.GetInstance().Load();
             ModuleDataManager.GetInstance().FilterAliasTree(treeView, null);
             searchBox.BackColor = SystemColors.Window;
@@ -56,10 +56,13 @@ namespace StonehearthEditor
                 return; // Don't know how to clone something not module file data
             }
 
-            string manifestEntryType = selectedNode.Parent.Text;
-            string name = moduleFile.GetModuleFile() != null ? moduleFile.GetModuleFile().FullAlias : selectedFileData.FileName;
+            // Get the correct type from any descendant nodes (including grandchildren)
+            string manifestEntryType = selectedNode.FullPath.Split('\\')[1];
+            string sourceModName = selectedNode.FullPath.Split('\\')[0];
+            ModuleFile sourceModule = moduleFile.GetModuleFile();
+            string uri = sourceModule != null ? sourceModule.FullAlias : selectedFileData.FileName;
             CloneAliasCallback callback = new CloneAliasCallback(this, selectedFileData, manifestEntryType);
-            CloneDialog dialog = new CloneDialog(name, selectedFileData.GetNameForCloning());
+            CloneDialog dialog = new CloneDialog(uri, selectedFileData.GetNameForCloning(), sourceModName);
             dialog.SetCallback(callback);
             dialog.ShowDialog();
         }

--- a/StonehearthEditor/Module.cs
+++ b/StonehearthEditor/Module.cs
@@ -14,6 +14,7 @@ namespace StonehearthEditor
 
         private string mPath;
         private string mName;
+        private string mParentDirectory;
         private JObject mManifestJson;
         private FileSystemWatcher mFileWatcher;
         private DateTime mLastReadTime = DateTime.MinValue;
@@ -35,6 +36,7 @@ namespace StonehearthEditor
         {
             mPath = modPath;
             mName = modPath.Substring(modPath.LastIndexOf('/') + 1);
+            mParentDirectory = modPath.Substring(0, modPath.LastIndexOf('/'));
         }
 
         public ICollection<ModuleFile> GetAliases()
@@ -55,6 +57,11 @@ namespace StonehearthEditor
         public string Path
         {
             get { return mPath; }
+        }
+
+        public string ParentDirectory
+        {
+            get { return mParentDirectory; }
         }
 
         public JObject EnglishLocalizationJson

--- a/StonehearthEditor/ModuleFile.cs
+++ b/StonehearthEditor/ModuleFile.cs
@@ -147,7 +147,7 @@ namespace StonehearthEditor
                 return false;
             }
 
-            string modPath = MainForm.kModsDirectoryPath;
+            string modPath = targetModule.ParentDirectory;
             string relativePath = ResolvedPath.Replace(mModule.Path + "/", "");
             string newPath = parameters.TransformParameter(relativePath);
             string fullPath = modPath + "/" + targetModName + "/" + newPath;

--- a/StonehearthEditor/Program.cs
+++ b/StonehearthEditor/Program.cs
@@ -12,14 +12,19 @@ namespace StonehearthEditor
         private static void Main(string[] args)
         {
             string path = (string)Properties.Settings.Default["ModsDirectory"];
+            string steamUploadsPath = (string)Properties.Settings.Default["SteamUploadsDirectory"];
             if (args.Length > 0)
             {
                 path = args[0];
             }
+            if (args.Length > 1)
+            {
+                steamUploadsPath = args[1];
+            }
 
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
-            Application.Run(new MainForm(path));
+            Application.Run(new MainForm(path, steamUploadsPath));
         }
     }
 }

--- a/StonehearthEditor/Properties/Settings.Designer.cs
+++ b/StonehearthEditor/Properties/Settings.Designer.cs
@@ -118,5 +118,17 @@ namespace StonehearthEditor.Properties {
                 this["LastSelectedItemsTypeIndex"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string SteamUploadsDirectory {
+            get {
+                return ((string)(this["SteamUploadsDirectory"]));
+            }
+            set {
+                this["SteamUploadsDirectory"] = value;
+            }
+        }
     }
 }

--- a/StonehearthEditor/Properties/Settings.settings
+++ b/StonehearthEditor/Properties/Settings.settings
@@ -26,5 +26,8 @@
     <Setting Name="LastSelectedItemsTypeIndex" Type="System.String" Scope="User">
       <Value Profile="(Default)">0</Value>
     </Setting>
+    <Setting Name="SteamUploadsDirectory" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/StonehearthEditor/Recipes/RecipesView.cs
+++ b/StonehearthEditor/Recipes/RecipesView.cs
@@ -418,21 +418,24 @@ namespace StonehearthEditor.Recipes
         private void LoadMaterialImages()
         {
             Module sh = ModuleDataManager.GetInstance().GetMod("stonehearth");
-            ModuleFile resourceConstants = sh.GetAliasFile("data:resource_constants");
-            if (resourceConstants != null)
+            if (sh != null)
             {
-                JsonFileData jsonFileData = resourceConstants.FileData as JsonFileData;
-                JObject resourceConstantsJson = jsonFileData.Json;
-                JObject resourceJson = resourceConstantsJson["resources"] as JObject;
-
-                foreach (JProperty resource in resourceJson.Properties())
+                ModuleFile resourceConstants = sh.GetAliasFile("data:resource_constants");
+                if (resourceConstants != null)
                 {
-                    string name = resource.Name;
-                    string iconLocation = resource.Value["icon"].ToString();
-                    string path = JsonHelper.GetFileFromFileJson(iconLocation, jsonFileData.Directory);
-                    if (path != "" && System.IO.File.Exists(path))
+                    JsonFileData jsonFileData = resourceConstants.FileData as JsonFileData;
+                    JObject resourceConstantsJson = jsonFileData.Json;
+                    JObject resourceJson = resourceConstantsJson["resources"] as JObject;
+
+                    foreach (JProperty resource in resourceJson.Properties())
                     {
-                        mMaterialImages.Add(name, path);
+                        string name = resource.Name;
+                        string iconLocation = resource.Value["icon"].ToString();
+                        string path = JsonHelper.GetFileFromFileJson(iconLocation, jsonFileData.Directory);
+                        if (path != "" && System.IO.File.Exists(path))
+                        {
+                            mMaterialImages.Add(name, path);
+                        }
                     }
                 }
             }

--- a/StonehearthEditor/StonehearthEditor.csproj
+++ b/StonehearthEditor/StonehearthEditor.csproj
@@ -118,6 +118,18 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Dialogs\AboutDialog.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="Dialogs\AboutDialog.Designer.cs">
+      <DependentUpon>AboutDialog.cs</DependentUpon>
+    </Compile>
+    <Compile Include="Dialogs\ModDirectorySettingsDialog.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="Dialogs\ModDirectorySettingsDialog.Designer.cs">
+      <DependentUpon>ModDirectorySettingsDialog.cs</DependentUpon>
+    </Compile>
     <Compile Include="LoadingSplash.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -246,6 +258,12 @@
     <Compile Include="Recipes\RecipesView.Designer.cs">
       <DependentUpon>RecipesView.cs</DependentUpon>
     </Compile>
+    <EmbeddedResource Include="Dialogs\AboutDialog.resx">
+      <DependentUpon>AboutDialog.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Dialogs\ModDirectorySettingsDialog.resx">
+      <DependentUpon>ModDirectorySettingsDialog.cs</DependentUpon>
+    </EmbeddedResource>
     <EmbeddedResource Include="LoadingSplash.resx">
       <DependentUpon>LoadingSplash.cs</DependentUpon>
     </EmbeddedResource>
@@ -371,7 +389,9 @@
     <None Include="StonehearthEditor.ruleset" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="App.config" />
+    <None Include="App.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include=".NETFramework,Version=v4.5.2">

--- a/StonehearthEditor/defaultJson/defaultManifest.json
+++ b/StonehearthEditor/defaultJson/defaultManifest.json
@@ -1,10 +1,11 @@
 {
    "info" : {
       "name": "TestMod",
-      "version": 2
+      "namespace" : "test_mod",
+      "version": 3
    },
    "default_locale" : "en",
-   "aliases" : {      
+   "aliases" : {
    },
    "mixintos" : {
    },


### PR DESCRIPTION
This is ugly code and I should have tried to separate the commits.

* Added initial support for steam_uploads folder. (Now we can add an additional path to load mods from, they will be loaded at the bottom of the tree view, and we can clone anything in the tree view to any mod listed there. It makes possible to clone jobs, recipe indexes, etc).
* Fixed manifest template.
* Added Help menu item with an About submenu that opens About dialog linking to shed repo and to modding guide.
* Added checkbox to check/uncheck all in preview clone dialog (since now we can clone recipe indexes, which will try to clone all the produced items).
* Fixed some NPE exceptions that I was hitting while testing. Not all are fixed, SHED can still crash if we don't fix the wrong paths right after cloning and try to go to other views. It will also hang a little sometimes when editing files (but less than before), and the loc scripts still work for some files but not for others (not sure why, I cloned two recipes separately and for one it would work but not for the other one).

Hopefully these fixes will make SHED crash a little less and be more usable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stonehearth/stonehearth-editor/12)
<!-- Reviewable:end -->
