### PR TITLE
Small correction to the northern_alliance alias

### DIFF
--- a/StonehearthEditor/schemas/encounters/elements/kingdom.json
+++ b/StonehearthEditor/schemas/encounters/elements/kingdom.json
@@ -7,7 +7,7 @@
    "enum": [
       "stonehearth:kingdoms:ascendancy",
       "rayyas_children:kingdoms:rayyas_children",
-      "stonehearth:kingdoms:northern_alliance",
+      "northern_alliance:kingdoms:northern_alliance",
       "stonehearth:kingdoms:human_npcs",
       "stonehearth:kingdoms:animals",
       "stonehearth:kingdoms:forest",


### PR DESCRIPTION
Else shed would claim there was an error in your campaign node wherever you pointed to that kingdom.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stonehearth/stonehearth-editor/13)
<!-- Reviewable:end -->
